### PR TITLE
fix(ui): restore desktop navbar visibility on Tailwind 4

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -41,7 +41,7 @@ function isActive(href: string): boolean {
       </div>
     </div>
 
-    <MenuItems class="hidden lg:flex lg:flex-grow lg:justify-end">
+    <MenuItems class="hidden lg:!flex lg:flex-grow lg:justify-end">
       <nav aria-label="Main navigation">
         <ul class="flex flex-col lg:w-full lg:flex-row lg:gap-1">
           {navItems.map((item) => (


### PR DESCRIPTION
## Summary

Tailwind 4 broke the desktop navbar visibility. At viewport ≥ 1024px (lg breakpoint), the entire `Home / Blog / Profile / Status` nav was rendering with `display: none` instead of becoming a flex container.

Bumping the responsive override to `lg:!flex` (important variant) unambiguously beats the base `hidden` declaration.

## Root cause

The `<MenuItems>` wrapper had classes `hidden lg:flex lg:flex-grow lg:justify-end`. In Tailwind 3, source-order made `lg:flex` win at the lg breakpoint. In Tailwind 4, class precedence rules changed around responsive variants combined with display utilities — `hidden` was winning unconditionally.

DOM verification (Playwright, 1440×900 viewport) on the live Worker:
```
outerNavDisplay: "none"    ← bug
outerNavClass: "astronav-items astronav-toggle hidden lg:flex lg:flex-grow lg:justify-end"
visibleNavLinks: []
```

After fix:
```
outerNavDisplay: "flex"
outerNavClass: "astronav-items astronav-toggle hidden lg:!flex lg:flex-grow lg:justify-end"
visibleNavLinks: ["Home", "Blog", "Profile", "Status", "Protected", "Login"]
```

## Verification

- ✅ `bun run build` clean
- ✅ `astro check` 0/0/0
- ✅ Playwright DOM eval at 1440×900: all nav links render with non-zero bounding boxes
- ✅ Visual screenshot confirms parity with legacy `codeseys.io` desktop layout

## Stack

This is **PR 1 of 2** in a stack:

1. ➡️ **#3 — Restore desktop navbar visibility** (this PR)
2. **#4 — Hide auth nav when OIDC not configured** (depends on #3)

Merge bottom-up: #3 first, then rebase + merge #4.
