### PR TITLE
feat(ui): hide auth nav items when OIDC is not configured

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,19 +2,30 @@
 import ThemeToggle from '@/components/ThemeToggle.astro'
 import { Astronav, MenuIcon, MenuItems } from 'astro-navbar'
 import CarbonParameter from '~icons/carbon/parameter'
+import { isAuthConfigured, type AuthEnv } from '@/lib/auth'
+import { getRuntimeEnv } from '@/lib/runtime-env'
 
 const { session } = Astro.locals
 const isAuthed = Boolean(session)
 
+// Only show Protected + Login/Logout nav items when OIDC is actually
+// configured for this deployment. Without this gate, anonymous visitors
+// see auth-only entry points that 401 on click. Mirrors the legacy site's
+// nav (Home / Blog / Profile / Status) when auth is disabled.
+const authConfigured = isAuthConfigured(getRuntimeEnv<AuthEnv>())
+
 const pathname = Astro.url.pathname
 
-const navItems = [
+const baseNavItems = [
   { href: '/', label: 'Home' },
   { href: '/blog', label: 'Blog' },
   { href: '/profile', label: 'Profile' },
   { href: '/status', label: 'Status' },
-  { href: '/protected', label: 'Protected' },
 ]
+
+const navItems = authConfigured
+  ? [...baseNavItems, { href: '/protected', label: 'Protected' }]
+  : baseNavItems
 
 function isActive(href: string): boolean {
   if (href === '/') return pathname === '/'
@@ -60,17 +71,19 @@ function isActive(href: string): boolean {
               </a>
             </li>
           ))}
-          <li class="mt-2 lg:mt-0">
-            <a
-              href={isAuthed ? '/api/auth/logout' : '/login'}
-              class:list={[
-                'block rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-              ]}
-            >
-              {isAuthed ? 'Logout' : 'Login'}
-            </a>
-          </li>
+          {authConfigured && (
+            <li class="mt-2 lg:mt-0">
+              <a
+                href={isAuthed ? '/api/auth/logout' : '/login'}
+                class:list={[
+                  'block rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                  'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                ]}
+              >
+                {isAuthed ? 'Logout' : 'Login'}
+              </a>
+            </li>
+          )}
         </ul>
       </nav>
     </MenuItems>


### PR DESCRIPTION
## Summary

The new nav was leaking `/protected` and `/login` to anonymous visitors on deployments without any OIDC config — clicking either yielded a 401, and they visibly diverge from the legacy site's clean Home/Blog/Profile/Status nav.

Gate both behind `isAuthConfigured(getRuntimeEnv<AuthEnv>())` from `@/lib/auth`. The runtime-env shim handles the Workers `cloudflare:workers` env import, so the same code path works in dev, preview, and prod.

## Behavior

| OIDC configured? | Nav items |
|---|---|
| ❌ No (default) | Home / Blog / Profile / Status |
| ✅ Yes | Home / Blog / Profile / Status / **Protected** / **Login** (or Logout if signed in) |

## Activation

When OIDC is later configured (`AUTH_SESSION_SECRET` + `OIDC_*` / `AUTH0_*` / `KEYCLOAK_*` set on the Worker), Protected and Login/Logout re-appear automatically. **No code change needed to enable auth — just `wrangler secret put`.**

## Verification

- ✅ `bun run build` clean
- ✅ `astro check` 0/0/0
- ✅ Playwright DOM eval at 1440×900: only `Home / Blog / Profile / Status` render with no auth env vars set
- ✅ Visual screenshot confirms parity with legacy `codeseys.io` desktop nav

## Stack

This is **PR 2 of 2** in a stack:

1. **#3 — Restore desktop navbar visibility** (depends on this)
2. ➡️ **#4 — Hide auth nav when OIDC not configured** (this PR — base: `stack/01-navbar-tailwind4-fix`)

Merge order: #3 first, then this PR will rebase onto main automatically.
