### PR TITLE
fix(og): anchor og:image URL on request origin not Astro.site

### DIFF
--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -33,9 +33,14 @@ const resolvedTitle = Astro.props.title ?? siteName
 const resolvedDescription = Astro.props.description ?? defaultDescription
 
 // Build the dynamic OG image URL when no explicit override is provided.
-// Threads title + description through so unfurls match the page.
+// We anchor on `Astro.url.origin` (the host the *current request* is being
+// served from) rather than `Astro.site` so the og:image URL always lives
+// on the same origin as the page being shared. That way the social
+// scraper hits the same Worker that produced the og tags, instead of
+// (during the apex transition) falling back to whatever else is parked
+// on the canonical `Astro.site` host.
 function buildDynamicOgUrl(): URL {
-  const u = new URL('/api/og.png', Astro.site)
+  const u = new URL('/api/og.png', Astro.url.origin)
   u.searchParams.set('title', resolvedTitle)
   u.searchParams.set('description', resolvedDescription)
   if (Astro.props.ogTag) u.searchParams.set('tag', Astro.props.ogTag)


### PR DESCRIPTION
Follow-up to #9. Until apex cutover, codeseys.io points at the old GH Pages site and 404s on /api/og.png — so external scrapers fail to load the og image. Switching to Astro.url.origin keeps the og URL on the same host as the page being shared. After apex cutover this is still correct because origin == codeseys.io for canonical traffic.

Tested:
- bun run astro check: 0/0/0
- bun run build: green