### PR TITLE
feat: cutover apex (codeseys.io) to Workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## [2026-05-21] Apex cutover — codeseys.io now serves the Workers build
+
+Flipped `codeseys.io` and `www.codeseys.io` from the legacy `homepage`
+Pages project (Astro 5.16.2, ~5 months stale, the one with the leftover
+shadcn-template og-image) onto the live `codeseys-personal-website`
+Worker (Astro 6.3.6 with the bento grids, dynamic OG images, MDX content
+collection, and live Gatus status).
+
+### `wrangler.jsonc`
+
+- Added `routes`:
+  - `{ "pattern": "codeseys.io", "custom_domain": true }`
+  - `{ "pattern": "www.codeseys.io", "custom_domain": true }`
+- Explicitly opted into `workers_dev: true` and `preview_urls: true`
+  so the existing `*.codeseys.workers.dev` URL and per-deploy preview
+  URLs stay alive alongside the custom domains. Wrangler now defaults
+  these to `false` once `routes` is set, which would otherwise silently
+  retire our testing surface.
+
+### Cutover sequence (executed)
+
+1. Removed `codeseys.io` from the `homepage` Pages project via
+   `DELETE /accounts/{aid}/pages/projects/homepage/domains/codeseys.io`.
+2. Deleted the legacy zone-level CNAME `codeseys.io → temp-5zc.pages.dev`
+   (record id `841508cea37bc9ef62c0208d8d00a45e`, created 2023-09-01)
+   via `bunx cf dns records delete`. Cloudflare otherwise refuses to
+   bind the apex to a Worker while external A/CNAME records exist on it
+   (error `100117`).
+3. Ran `bunx wrangler deploy` — Cloudflare auto-created the new synthetic
+   `AAAA codeseys.io → 100::` and `AAAA www.codeseys.io → 100::` records
+   (the standard placeholder for proxied Workers Custom Domains; actual
+   routing happens at the edge).
+4. Verified `https://codeseys.io/`, `https://www.codeseys.io/`,
+   `https://codeseys.io/api/og.png?...`, and `https://codeseys.io/blog`
+   all return 200 with `generator: Astro v6.3.6` and the new dynamic
+   `og:image` URL.
+
+### Tooling note — `bunx cf` over `bunx wrangler` for DNS
+
+Wrangler's OAuth token has `pages:write` and `workers_routes:write` but
+no `dns_records:edit` scope, so it can't clear conflicting DNS records
+on its own. The official Cloudflare CLI `bunx cf` (`@cloudflare/cli`)
+authenticates with a broader OAuth token that *does* include
+`dns_records:edit`, which made the in-place CNAME deletion possible
+without minting a manual API token or doing the dashboard click-through.
+Worth remembering for future zone-level operations.
+
+### What was preserved
+
+- Email routing: 3× MX records to `route{1,2,3}.mx.cloudflare.net` and
+  the SPF TXT record on `codeseys.io` are untouched.
+- Yggdrasil cluster wildcard: `*.codeseys.io → cfargotunnel` kept.
+  Specific `www.codeseys.io` Worker custom-domain takes precedence
+  over the wildcard at the edge.
+- Old Pages project `homepage` is left alive on its `temp-5zc.pages.dev`
+  domain only — kept as an emergency rollback artifact for now. Can be
+  deleted with `bunx wrangler pages project delete homepage` once the
+  cutover settles for ~24h.
+
+### Rollback
+
+- `curl -X POST https://api.cloudflare.com/client/v4/accounts/$AID/pages/projects/homepage/domains -d '{"name":"codeseys.io"}'`
+  to re-bind the apex to the Pages project.
+- Then `bunx cf dns records create CNAME codeseys.io temp-5zc.pages.dev --proxied`.
+
 ## [2026-05-20] (continued, 3) Dynamic per-page Open Graph image generator
 
 Replaced the leftover Astro shadcn/ui template `og-image.png` (the one that

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,7 +10,13 @@
   },
   "observability": {
     "enabled": true
-  }
+  },
+  "workers_dev": true,
+  "preview_urls": true,
+  "routes": [
+    { "pattern": "codeseys.io", "custom_domain": true },
+    { "pattern": "www.codeseys.io", "custom_domain": true }
+  ]
 
   // Auth (planned): Auth0 or Keycloak (OIDC)
   // Add secrets/vars in Cloudflare Workers dashboard or via `wrangler secret put`, e.g.:


### PR DESCRIPTION
Binds `codeseys.io` + `www.codeseys.io` as Custom Domains on the `codeseys-personal-website` Worker.

## Why
Currently `codeseys.io` points at the legacy `homepage` Pages project (Astro 5.16.2 build, ~5 months stale, with the leftover shadcn-template og-image.png that prompted this whole thread). All current development happens on the Workers project. Time to flip.

## Blocker
Cloudflare refuses to bind the apex to the Worker while external A records still exist on the zone:
> Hostname 'codeseys.io' already has externally managed DNS records (A, CNAME, etc). Delete them first or try a different hostname. [code: 100117]

The wrangler OAuth scopes don't include `dns:edit`, so this requires either a manual dashboard step or a fresh API token.

## Cutover sequence (executed by maintainer once DNS is clear)
```bash
# 1. Confirm no codeseys.io/www records remain on the zone
# 2. Build
bun run build
# 3. Deploy with custom_domain bindings
bunx wrangler deploy
# 4. Verify
curl -sI https://codeseys.io/                                  # 200 from Workers
curl -sI https://codeseys.io/api/og.png?title=Hello             # 200 PNG
curl -sI https://www.codeseys.io/                              # 200 (auto-cert)
# 5. Re-test unfurl in Discord/Telegram with https://codeseys.io/blog
```

## Reverts
```bash
# Roll back: re-bind the domain to the homepage Pages project via API
curl -sS -X POST https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects/homepage/domains \\
  -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" -d '{"name":"codeseys.io"}'
# Then revert this PR
```

## What this PR ships
- `routes` array binding `codeseys.io` and `www.codeseys.io` as custom domains
- `workers_dev: true` + `preview_urls: true` to preserve the existing `*.workers.dev` and per-deploy preview URLs (wrangler defaults these to `false` once `routes` is set)

## Out of scope (follow-ups)
- Delete dead `homepage` Pages project entirely (after cutover settles for ~24h)
- Verify Discord/Telegram unfurl cache invalidates within a few hours