### PR TITLE
fix(ui): restore desktop theme-toggle button (Tailwind 4 cascade)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -48,7 +48,7 @@ function isActive(href: string): boolean {
       </a>
       <div class="ml-auto flex items-center space-x-4">
         <MenuIcon class="order-2 h-6 w-6 cursor-pointer lg:hidden" />
-        <div class="order-1 lg:ml-4 lg:hidden"><ThemeToggle /></div>
+        <div class="order-1 lg:ml-4 lg:hidden"><ThemeToggle id="theme-toggle-mobile" /></div>
       </div>
     </div>
 
@@ -87,8 +87,8 @@ function isActive(href: string): boolean {
         </ul>
       </nav>
     </MenuItems>
-    <div class="hidden lg:flex lg:items-center lg:pl-4">
-      <ThemeToggle />
+    <div class="hidden lg:!flex lg:items-center lg:pl-4">
+      <ThemeToggle id="theme-toggle-desktop" />
     </div>
   </Astronav>
 </header>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,41 +1,54 @@
 ---
 import { Moon, Sun } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+
+// Each ThemeToggle gets a unique id so we can render multiple instances
+// (mobile + desktop) on the same page without colliding for getElementById.
+// Defaults preserve the original single-instance contract.
+interface Props {
+  id?: string
+}
+const { id = 'theme-toggle' } = Astro.props
 ---
 
-<Button variant="ghost" size="icon" id="theme-toggle" aria-label="Toggle theme">
+<Button
+  variant="ghost"
+  size="icon"
+  id={id}
+  data-theme-toggle
+  aria-label="Toggle theme"
+>
   <Sun className="h-[1.5rem] w-[1.3rem] dark:hidden" />
   <Moon className="hidden h-5 w-5 dark:block" />
   <span class="sr-only">Toggle theme</span>
 </Button>
 
 <script>
-  function setupThemeToggle() {
-    const toggle = document.getElementById('theme-toggle')
-    if (!toggle) return
+  // Wire ALL theme toggles on the page (mobile + desktop) — selected by the
+  // [data-theme-toggle] attribute, not by id, so any number of instances
+  // share the same handler. The previous version used getElementById which
+  // only ever attached to the first match, leaving the desktop toggle dead.
+  function setupThemeToggles() {
+    const toggles = document.querySelectorAll<HTMLElement>('[data-theme-toggle]')
+    toggles.forEach((toggle) => {
+      // Replace node to drop any prior listeners (covers Astro view-transition rehydration)
+      const fresh = toggle.cloneNode(true) as HTMLElement
+      toggle.parentNode?.replaceChild(fresh, toggle)
 
-    // Remove any existing listeners by cloning
-    const newToggle = toggle.cloneNode(true)
-    toggle.parentNode?.replaceChild(newToggle, toggle)
-
-    newToggle.addEventListener('click', () => {
-      // Disable transitions during theme change for instant switch
-      document.documentElement.classList.add('theme-transition-disabled')
-
-      // Toggle the theme
-      const isDark = document.documentElement.classList.toggle('dark')
-      localStorage.setItem('theme', isDark ? 'dark' : 'light')
-
-      // Re-enable transitions after a brief moment
-      requestAnimationFrame(() => {
+      fresh.addEventListener('click', () => {
+        // Disable transitions during the swap to avoid a brief crossfade flicker
+        document.documentElement.classList.add('theme-transition-disabled')
+        const isDark = document.documentElement.classList.toggle('dark')
+        localStorage.setItem('theme', isDark ? 'dark' : 'light')
         requestAnimationFrame(() => {
-          document.documentElement.classList.remove('theme-transition-disabled')
+          requestAnimationFrame(() => {
+            document.documentElement.classList.remove('theme-transition-disabled')
+          })
         })
       })
     })
   }
 
-  // Run on initial load and after page transitions
-  setupThemeToggle()
-  document.addEventListener('astro:page-load', setupThemeToggle)
+  setupThemeToggles()
+  document.addEventListener('astro:page-load', setupThemeToggles)
 </script>


### PR DESCRIPTION
Closes the bug where the desktop theme-toggle button was invisible on >=lg viewports while the mobile one worked fine.

## Two bugs converged

**1. Tailwind 4 cascade ordering.** The header-right wrapper used `hidden lg:flex`. In the bundled CSS, plain `.hidden { display: none }` lands source-order-LATER than `.lg\:flex { display: flex }` even at the lg breakpoint, so `display: none` wins. Same trap that bit us in stack/01-navbar-tailwind4-fix; the `MenuItems` wrapper already used `lg:!flex` to win the cascade — the desktop toggle wrapper didn't.

**2. Duplicate `id="theme-toggle"`.** The component was rendered twice (mobile + desktop) with the same id. Script used `getElementById` which only matches the first → desktop button never got the click handler. Bug #1 was masking this anyway.

## Fixes

- `Header.astro`: `hidden lg:flex` → `hidden lg:!flex` on desktop toggle wrapper. Pass unique `id` prop to each instance.
- `ThemeToggle.astro`: now accepts an `id` prop. Renders a `[data-theme-toggle]` data attribute. Script selects ALL `[data-theme-toggle]` elements and wires each one independently.

## Verified live (deployed before PR for confirmation)

- 1600×900 viewport: desktop toggle visible at (1540, 20), 40×40px ✓
- Click toggles `html.dark` class ✓
- `localStorage.theme` persists ✓
- Mobile (<lg) still works ✓