### PR TITLE
docs: project-embeds architecture + companion blog post

### DIFF
--- a/docs/PROJECT_EMBEDS.md
+++ b/docs/PROJECT_EMBEDS.md
@@ -1,0 +1,498 @@
+# Project Embeds Architecture
+
+> How `codeseys.io` discovers and embeds interactable versions of any project
+> (college, side, hackathon, work — anything that reaches a "works" state)
+> without ever building those projects in the personal-site repo.
+
+This document is the **canonical reference** when adding a new embeddable
+project to the site. Read this first before you start wiring up CI for a
+project — most of the work has been done; you just have to give your repo
+the right shape.
+
+---
+
+## TL;DR
+
+1. Tag your project repo on GitHub with the topic **`codeseys-embed`**.
+2. Drop a **`web.codeseys.json`** manifest at the repo root.
+3. Pick a **delivery mode** (build-time bundle, R2 runtime, or foreign-origin
+   runtime — see [Delivery modes](#delivery-modes)) and ship a CI workflow
+   that produces the artifact and publishes it to that location.
+4. The personal site picks the project up automatically on its next build:
+   it appears in `/projects`, gets its own page at `/projects/<slug>`, and
+   shows up as a `ProjectDemo` card in the bento grid.
+
+No submodules. No monorepo. No personal-site PR per project.
+
+---
+
+## Why this design
+
+The naive way to embed projects on a personal site is to add each one as a
+git submodule and have the personal site build them all. That tightly
+couples site deploys to project changes, makes auth painful for any
+private project, and inflates the Worker bundle past Cloudflare's free
+limits within a handful of additions.
+
+The architecture below decouples the two concerns:
+
+- **Each project owns its own build.** It compiles itself to a web-deployable
+  artifact (WASM, static HTML, rendered notebook, browser-DB seed, etc.)
+  and publishes that artifact to a stable public URL.
+- **The personal site only owns discovery and rendering.** It enumerates
+  repos by topic, fetches their manifests, validates them, and renders one
+  page per manifest. Pages mount a small embed component that loads the
+  artifact at the URL the manifest declares — or, for build-time-bundled
+  projects, at a same-origin path the site copied the artifact into during
+  its own build.
+
+The result: adding a new project to `codeseys.io` is a self-service action
+that lives entirely in the project's own repo.
+
+---
+
+## Architecture overview
+
+```
+                          GitHub
+                            │
+                            │ list repos with topic:codeseys-embed
+                            ▼
+              ┌────────────────────────────┐
+              │ sync-project-manifests.ts  │  prebuild step in this repo
+              │  (runs in personal-site CI)│
+              └─────────────┬──────────────┘
+                            │ for each repo:
+                            │   GET raw.githubusercontent.com/<repo>/HEAD/web.codeseys.json
+                            │   validate against zod schema
+                            │   if delivery.mode === 'bundle':
+                            │     fetch artifact, stage into dist/projects/<slug>/
+                            │     rewrite delivery.url to same-origin path
+                            │   write src/content/projects/<slug>.json
+                            ▼
+                   ┌──────────────────┐
+                   │ Astro content    │
+                   │   collection     │
+                   │   `projects`     │
+                   └────────┬─────────┘
+                            │
+                ┌───────────┴────────────┐
+                ▼                        ▼
+        /projects/index.astro      /projects/[slug].astro
+                                          │
+                                          ▼
+                                  <EmbedRouter manifest={...} />
+                                          │
+                                  switches on manifest.embed.kind
+                                          │
+                  ┌────────────────┬──────┴──────┬───────────────┐
+                  ▼                ▼             ▼               ▼
+            <WasmEmbed>     <IframeEmbed>  <NotebookEmbed>  <PGliteEmbed>  ...
+                                          │
+                                          │ fetch(manifest.delivery.url)
+                                          ▼
+                            artifact loads from same-origin (bundled)
+                            or assets-r2.codeseys.io (R2 runtime)
+                            or external origin (foreign runtime)
+```
+
+The personal site's only direct dependency on each project is **the URL of
+the artifact**. Project repos can be public or private; only the artifact
+has to be reachable at that URL.
+
+---
+
+## The manifest: `web.codeseys.json`
+
+Every embeddable project repo has this file at the repo root. The schema
+is enforced by zod (see [`src/lib/types/project-manifest.ts`](../src/lib/types/project-manifest.ts)).
+
+```json
+{
+  "schemaVersion": 1,
+  "slug": "example-bigint-calculator",
+  "category": { "kind": "college", "school": "UCSC", "code": "CSE 111", "title": "Compiler Design", "year": 2022 },
+  "title": "BigInt arbitrary-precision calculator",
+  "description": "Type expressions, see them parsed and evaluated in WebAssembly.",
+  "tags": ["compilers", "c++", "wasm"],
+  "thumbnail": "thumb.png",
+  "completionLevel": "ships",
+
+  "embed": {
+    "kind": "wasm-emscripten",
+    "entry": "bigint.js",
+    "memory": "16MB"
+  },
+
+  "delivery": {
+    "mode": "runtime-r2",
+    "url": "https://assets-r2.codeseys.io/example-bigint-calculator/abc1234/",
+    "version": "abc1234",
+    "sizeBytes": 412800
+  },
+
+  "build": {
+    "ci": true,
+    "workflow": ".github/workflows/build-web-asset.yml"
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `schemaVersion` | `1` | yes | Bumped when the schema breaks compat. |
+| `slug` | `string` (`[a-z0-9-]+`) | yes | URL slug. Must be globally unique. The site's route is `/projects/<slug>`. |
+| `category` | object | yes | See **Categories** below. |
+| `title` | `string` | yes | Card and page title. |
+| `description` | `string` | yes | One- or two-sentence pitch. Shown on the card and as the page intro. |
+| `tags` | `string[]` | no | Free-form. Used by the `/projects` filter. |
+| `thumbnail` | `string` | no | Path or URL of a card image. Resolved relative to `delivery.url` if not absolute. |
+| `completionLevel` | enum | yes | `wip` \| `works` \| `ships`. The site filters out `wip` from the homepage and only surfaces it on `/projects?show=wip`. |
+| `embed` | object | yes | Discriminated union by `kind`. See **Embed kinds** below. |
+| `delivery` | object | yes | How the site acquires and serves the artifact. See **Delivery modes** below. |
+| `build.ci` | `boolean` | yes | `true` if a CI workflow produces the artifact. `false` only for hand-published artifacts (legacy / one-offs). |
+| `build.workflow` | `string` | no | Path to the workflow file in the project repo, used for "view CI" links. |
+
+### Categories
+
+The `category` field tags the project by life-stage so the `/projects`
+page can group them sensibly:
+
+```ts
+type Category =
+  | { kind: 'college'; school: 'UCSC' | 'USC'; code: string; title: string; year: number }
+  | { kind: 'hackathon'; event: string; year: number }
+  | { kind: 'side'; year: number }                  // personal projects
+  | { kind: 'work'; org?: string; year: number }    // employer-permitted artifacts
+  | { kind: 'research'; venue?: string; year: number }
+```
+
+This deliberately replaces the original "college projects only" framing —
+the site's project section is for **anything I built that reaches a working
+state**, regardless of context.
+
+---
+
+## Embed kinds
+
+`embed.kind` is the contract between the artifact and the site's renderer.
+Each kind has a matching React component in `src/components/embeds/`.
+
+| `kind` | Use when… | Build target | Renderer component |
+|---|---|---|---|
+| `static-html` | The project is already a web page or SPA. | `dist/` of any static-site build (e.g. `vite build`) | `<IframeEmbed>` (sandboxed iframe) |
+| `wasm-emscripten` | C/C++/Rust-via-emcc that should run in browser. | `emcc` produces `*.js` + `*.wasm` | `<WasmEmbed>` |
+| `wasm-rust` | Rust that should run in browser. | `wasm-pack build --target web` | `<WasmEmbed>` (same component, different loader path) |
+| `pyodide` | Python algorithms (game agents, sims) that should be playable. | Python source + dependency list bundled with Pyodide loader | `<PyodideEmbed>` |
+| `notebook-html` | Jupyter notebook is the deliverable. | `jupyter nbconvert --to html` | `<NotebookEmbed>` (iframe of rendered HTML) |
+| `pglite-db` | DB project — schema, queries, optionally seed data. | A `schema.sql` and optional `seed.sql` are bundled. | `<PGliteEmbed>` (Postgres in browser via PGlite, includes a query runner) |
+| `tex-pdf` | LaTeX writeup — proofs, papers. | `latexmk` produces a PDF | `<PdfEmbed>` (PDF.js viewer) |
+| `external-app` | Project requires a server (a real DB, ML model, etc.). | Project deploys itself to Fly/Railway/etc. | `<IframeEmbed>` of the remote URL |
+
+Adding a new kind means: add a discriminant branch in the zod schema, add
+a renderer component, register it in `<EmbedRouter>`. That's it.
+
+### Why these eight cover almost everything
+
+- **`static-html`** absorbs every WebGL/Vue/React/Svelte assignment.
+- **`wasm-emscripten` + `wasm-rust`** absorb every native-code project that
+  doesn't talk to a real OS — algorithms, compilers, parsers, sims,
+  graphics, audio.
+- **`pyodide`** absorbs Python projects light enough to run client-side.
+  Game-playing agents are the killer use case.
+- **`notebook-html`** absorbs every "I have a Jupyter notebook" project at
+  the cost of being read-only. That's fine — recruiters mostly want to
+  see the code and the plots, not run the code.
+- **`pglite-db`** absorbs DB-class projects (full Postgres in WASM via
+  ElectricSQL's PGlite, including PostGIS).
+- **`tex-pdf`** absorbs theory writeups so you can list them next to code.
+- **`external-app`** is the escape hatch for anything too big to run in
+  the browser. Your project deploys itself; the site just iframes it.
+
+---
+
+## Delivery modes
+
+`delivery.mode` decouples **when** the site acquires the artifact from
+**where** it's served. Three modes, picked per project:
+
+| Mode | Acquired | Served from | Set `delivery.url` to |
+|---|---|---|---|
+| `bundle` | site CI at build time | same origin (`codeseys.io/projects/<slug>/`) | absolute URL the site fetches **once at build**; the site rewrites this to the same-origin path before writing the content entry |
+| `runtime-r2` ⭐ default | visitor at view time | `assets-r2.codeseys.io/<slug>/<version>/` | the public R2 URL that the project's CI uploaded to |
+| `runtime-foreign` | visitor at view time | wherever the project hosts it (gh-pages, Fly, the project's own Worker) | the public URL of the foreign deployment |
+
+### When to use each
+
+**`runtime-r2` — the default.** Use unless you have a specific reason not
+to. R2 is on the same root domain as the site (no per-project Pages
+config), versioned by SHA in the URL path (`<slug>/<version>/`), free
+storage at portfolio scale, and zero egress charges. The project's CI
+uploads to `s3://assets-r2/<slug>/<sha>/` via R2's S3-compatible API; the
+manifest's `delivery.url` points at the same SHA path. Atomic rollback =
+repoint the manifest at a previous SHA.
+
+**`bundle` — for small, safety-critical, or fully-offline-capable
+artifacts.** The site's prebuild step fetches the declared `delivery.url`
+once, copies the contents into `dist/projects/<slug>/`, and rewrites the
+content entry's URL to a same-origin path. Use when:
+
+- Artifact is small (< ~1 MB compressed). Anything bigger inflates the
+  Cloudflare Workers static-assets quota.
+- The project must work even if R2 / GitHub / external hosts are down
+  (true same-origin static asset).
+- You want zero runtime fetches — the artifact ships with the page.
+- CORS would otherwise be a hassle (e.g. WASM workers across origins).
+
+**`runtime-foreign` — escape hatch.** Use when the project already has a
+live deployment you'd rather embed than mirror, or when the project
+exposes a real server (Fly, Railway, Modal). The `external-app` embed
+kind almost always pairs with this delivery mode.
+
+> **Why R2 over per-repo gh-pages**: gh-pages was tempting (free, zero
+> setup) but it splits artifact hosting across `*.github.io` URLs you
+> don't control, breaks if Pages config drifts, has no per-version path
+> convention, and adds a third origin to the trust boundary. R2 with a
+> custom subdomain on the same eTLD+1 as the site is cleaner end-to-end.
+> `runtime-foreign` keeps gh-pages available for cases where it actually
+> fits (an external-app project that already deploys there).
+
+### Behavior in the personal-site discovery script
+
+```ts
+// pseudocode in src/scripts/sync-project-manifests.ts
+switch (manifest.delivery.mode) {
+  case 'bundle':
+    await fetchAndStage(manifest.delivery.url, `dist/projects/${manifest.slug}/`)
+    manifest.delivery.url = `/projects/${manifest.slug}/`  // rewrite to same-origin
+    break
+  case 'runtime-r2':
+  case 'runtime-foreign':
+    // leave url as-is; the embed component will fetch at view time
+    break
+}
+await writeContentEntry(manifest)
+```
+
+The renderer components are mode-agnostic: they take a `url` prop and
+load from it. The site doesn't care whether that URL is same-origin
+(because it was bundled) or external (because it's served live).
+
+---
+
+## Setting up `assets-r2.codeseys.io` (one-time)
+
+The R2 bucket and custom subdomain are shared across all projects. Set
+up once, used forever.
+
+1. **Create the bucket.** Cloudflare Dashboard → R2 → Create bucket →
+   name: `assets-r2`, location: auto.
+2. **Attach the custom domain.** In the bucket's **Settings** tab →
+   **Public access** → **Connect Domain** → `assets-r2.codeseys.io`.
+   Cloudflare auto-creates the CNAME because the apex (`codeseys.io`) is
+   already on Cloudflare DNS.
+3. **CORS rule on the bucket** (R2 → bucket → Settings → CORS Policy):
+   ```json
+   [
+     {
+       "AllowedOrigins": ["https://codeseys.io", "https://*.codeseys.io", "https://baladithyab.github.io", "http://localhost:4321"],
+       "AllowedMethods": ["GET", "HEAD"],
+       "AllowedHeaders": ["*"],
+       "MaxAgeSeconds": 3600
+     }
+   ]
+   ```
+4. **Generate an R2 API token** scoped to this bucket only, with
+   `Object Read & Write` permissions. Save the access key ID and secret
+   access key.
+5. **Store the credentials as GitHub organization secrets**, not per-repo,
+   so any project can use them. Add to all three orgs/users that host
+   embeddable projects (e.g. `Codeseys`, `Codeseys-Labs`, `baladithyab`):
+   - `R2_ACCESS_KEY_ID`
+   - `R2_SECRET_ACCESS_KEY`
+   - `R2_ENDPOINT_URL` (`https://<account_id>.r2.cloudflarestorage.com`)
+   - `R2_BUCKET` (`assets-r2`)
+6. **Test once** by uploading a hello-world artifact via `aws s3 cp` with
+   the R2 endpoint, then `curl https://assets-r2.codeseys.io/hello/index.html`
+   to confirm it serves with permissive CORS.
+
+After this, every project that wants `runtime-r2` delivery just calls
+the shared upload step in its CI; no per-project R2 setup needed.
+
+### Versioning convention
+
+Always upload to `<slug>/<git-sha>/`. Never to `<slug>/`. This means:
+
+- Two pushes to the same project don't race each other.
+- The manifest's `delivery.version` field unambiguously names which
+  artifact the manifest is referencing.
+- Rollback is a single-line manifest edit.
+- A "latest" alias can be done via a tiny redirect rule on the bucket if
+  ever needed, but most projects shouldn't bother — the site already
+  pins to a SHA per build.
+
+### Garbage collection
+
+R2 storage is cheap but not free. A monthly cron in this repo's CI
+(`scripts/r2-gc.ts`) lists `assets-r2/` prefixes, cross-references
+against the active manifest set, and deletes anything that's older than
+90 days **and** isn't referenced by any current manifest. Run it as a
+scheduled GitHub Action.
+
+---
+
+## Hosting summary
+
+The site ships from two domains, both first-class:
+
+- Primary: `codeseys.io` (Cloudflare Worker, see [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md))
+- Backup: `baladithyab.github.io` (GitHub Pages mirror)
+
+Embeds must work on either domain. That means:
+
+- **No hardcoded `codeseys.io` URLs** in renderers — relative paths and
+  `Astro.url.origin` only.
+- The R2 CORS rule whitelists both domains.
+- For `bundle` mode, both site builds copy the artifact into their own
+  `dist/projects/<slug>/`, so same-origin loading works on both.
+
+---
+
+## Private repos
+
+A private project repo can still publish a public artifact:
+
+- For **`runtime-r2`** mode: the private repo's CI pushes to the shared
+  R2 bucket using the org-secret credentials. The R2 URL is public; the
+  source stays private.
+- For **`bundle`** mode: same as above — the private repo's CI uploads
+  to R2, then the personal site's CI fetches from R2 at build time. The
+  R2 URL is the staging area whether you bundle or not.
+- For **`runtime-foreign`** + GitHub Pages: requires GitHub Pro for
+  public Pages on a private repo, or use a separate public mirror repo
+  (`<project>-public-artifacts`) whose only content is the built bundle.
+
+In every case, only the *behavior* of the project is exposed; the source
+code remains private.
+
+---
+
+## Discovery flow in the personal site
+
+Discovery runs at **build time** in this repo. The implementation lives
+in [`src/scripts/sync-project-manifests.ts`](../src/scripts/sync-project-manifests.ts)
+and is wired into `package.json` as a `prebuild` script.
+
+It:
+
+1. Lists repos under the configured GitHub accounts (`Codeseys`,
+   `Codeseys-Labs`, `baladithyab`) that have the topic `codeseys-embed`.
+2. For each repo, fetches the manifest from
+   `https://raw.githubusercontent.com/<owner>/<repo>/HEAD/web.codeseys.json`.
+   For private repos, it falls back to fetching the manifest from R2
+   (the project's CI uploads the manifest alongside the artifact).
+3. Validates each manifest against the zod schema. Invalid manifests are
+   skipped and logged (the build does not fail — a bad manifest in one
+   project should never block a site deploy).
+4. **For `bundle` mode**: fetches `delivery.url`, copies the contents
+   into `dist/projects/<slug>/`, rewrites `delivery.url` to the
+   same-origin path. Validates against `delivery.sizeBytes` to catch
+   surprise blowouts.
+5. Writes `src/content/projects/<slug>.json` for each valid manifest.
+
+Astro's content collection (`projects`, defined in
+[`src/content.config.ts`](../src/content.config.ts)) picks these up and
+exposes them to pages at build time.
+
+If you ever want **runtime** discovery (manifest changes appear on the
+site without a redeploy), the same script can run inside the Worker on a
+cron and write to KV — but build-time is the default.
+
+---
+
+## Adding a new project: end-to-end checklist
+
+1. **Get your project to a "works" state.** It doesn't need to be polished;
+   `completionLevel: "works"` is a valid state. `wip` is also allowed but
+   hidden by default.
+2. **Pick the embed kind.** Look at the table above. If your project
+   doesn't fit any of them, ask whether you really need a new kind or
+   whether `external-app` (deploy somewhere, iframe it) is enough.
+3. **Pick the delivery mode.** `runtime-r2` for almost everything,
+   `bundle` for small fully-offline-capable artifacts, `runtime-foreign`
+   for projects with their own existing live deployment.
+4. **Author `web.codeseys.json`** at the repo root. Validate it locally
+   with the schema (you can run the personal-site script against it via
+   `bun run scripts/sync-project-manifests.ts --local <path>`).
+5. **Write the build workflow** in your project repo. Reusable workflows
+   live at `Codeseys-Labs/web-embed-workflows/.github/workflows/`. Your
+   workflow is typically 10 lines:
+   ```yaml
+   on:
+     push: { branches: [main] }
+     workflow_dispatch:
+   jobs:
+     build:
+       uses: Codeseys-Labs/web-embed-workflows/.github/workflows/wasm-emscripten.yml@main
+       with:
+         manifest: web.codeseys.json
+       secrets: inherit  # picks up R2_* org secrets for upload
+   ```
+6. **Verify the artifact**. Push, watch CI, confirm:
+   - `runtime-r2`: `curl https://assets-r2.codeseys.io/<slug>/<sha>/` returns the entrypoint.
+   - `bundle`: same as above (R2 is the staging area for bundle mode too).
+   - `runtime-foreign`: the foreign URL is reachable and CORS-permissive.
+7. **Add the GitHub topic `codeseys-embed`** to the repo. Until you do
+   this, the personal site will never discover it.
+8. **Trigger a personal-site rebuild** (push any change, or run the
+   "redeploy" workflow). The new project appears at `/projects/<slug>`.
+
+If anything is missing or wrong, the personal-site build logs will name
+the project and the failing field. The build does not break.
+
+---
+
+## Constraints, pitfalls, and policies
+
+- **No project source bundled into this repo.** The personal site never
+  takes a build dependency on a project's source. If you find yourself
+  importing from a project repo, stop and put a manifest there instead.
+- **Cloudflare Worker bundle stays small.** Embeds load artifacts via
+  `<script src>` / `<iframe src>` from R2 or external URLs at runtime;
+  nothing bigger than the small embed components is bundled into the
+  Worker. `bundle` mode artifacts go into `dist/` (Workers static
+  assets), which has its own quota — keep individual bundles under
+  ~1 MB.
+- **Slugs are global and immutable once published.** Renaming a slug
+  breaks any external link to `/projects/<old-slug>`. Add an alias in the
+  manifest (`legacySlugs`) instead — coming in `schemaVersion: 2`.
+- **Manifests must validate or they're silently skipped.** This is
+  intentional. The site never fails to deploy because a project repo has
+  a typo in its manifest.
+- **Sandbox iframes by default.** All `<IframeEmbed>` instances apply
+  `sandbox="allow-scripts allow-same-origin"`. Loosen on a per-kind basis
+  only when necessary.
+- **Academic-integrity audit before flipping repos public.** Some
+  university courses prohibit publicly posting submitted work. The
+  artifact-only path (private source, public R2 artifact) sidesteps this:
+  visitors can use the project but can't fork the source.
+- **Always pin to a SHA in the R2 path.** Never overwrite `<slug>/` directly.
+  Versioned paths make rollback a one-line manifest edit.
+- **CORS lockdown matters.** The bucket whitelists `codeseys.io`,
+  `*.codeseys.io`, `baladithyab.github.io`, and `localhost:4321` only.
+  Don't open it to `*` — the bucket is for this site's embeds, not for
+  general public hotlinking.
+
+---
+
+## Reference
+
+- Manifest schema: [`src/lib/types/project-manifest.ts`](../src/lib/types/project-manifest.ts)
+- Discovery script: [`src/scripts/sync-project-manifests.ts`](../src/scripts/sync-project-manifests.ts)
+- R2 garbage-collection script: [`src/scripts/r2-gc.ts`](../src/scripts/r2-gc.ts)
+- Embed components: [`src/components/embeds/`](../src/components/embeds/)
+- Routes: [`src/pages/projects/index.astro`](../src/pages/projects/index.astro), [`src/pages/projects/[slug].astro`](../src/pages/projects/[slug].astro)
+- Reusable CI workflows: [Codeseys-Labs/web-embed-workflows](https://github.com/Codeseys-Labs/web-embed-workflows)
+- Companion blog post: [`/blog/build-anything-make-it-playable-an-architecture-for-discoverable-project-embeds`](../src/content/blog/build-anything-make-it-playable-an-architecture-for-discoverable-project-embeds.mdx)

--- a/src/content/blog/build-anything-make-it-playable-an-architecture-for-discoverable-project-embeds.mdx
+++ b/src/content/blog/build-anything-make-it-playable-an-architecture-for-discoverable-project-embeds.mdx
@@ -1,0 +1,409 @@
+---
+title: 'Build anything, make it playable: an architecture for discoverable project embeds'
+description: 'How a personal site can host live, interactable versions of every project you ship — without ever building those projects in the site repo. A discovery-by-manifest architecture using GitHub topics, per-repo CI, three pluggable delivery modes, WebAssembly, and PGlite.'
+publishedAt: '2026-05-27'
+tags: ['architecture', 'webassembly', 'astro', 'cloudflare', 'meta', 'portfolio']
+draft: false
+featured: true
+---
+
+import { Image } from 'astro:assets'
+
+A personal site that lists projects is fine. A personal site where you can
+**actually use the projects** — type input into a compiler, query a
+database in the browser, play against an old game-playing agent, watch a
+graph algorithm animate while you click vertices — is a different thing.
+It crosses the line between portfolio and product.
+
+This is how I'm building that. The architecture is generic — none of it
+is specific to my projects, none of it is specific to college work. Any
+working project, in any language, by anyone with a personal site, can
+fit through this pipe.
+
+## The framing
+
+You have a pile of working projects. They live in their own repos. They
+were written in different languages, different years, for different
+purposes. A few of them have web UIs already. Most don't.
+
+The naive way to put live versions on your personal site is:
+
+- Add each project as a git submodule.
+- Build everything in the site's CI.
+- Bundle it all into one deploy.
+
+This is a trap. It tightly couples the cadence of your site deploys to
+the cadence of every project you've ever embedded. It makes private
+projects auth-painful in CI. The site bundle blows past Cloudflare's
+free Worker limit (10 MB compressed) within five or six WebAssembly
+modules. And the friction of "add a project" becomes high enough that
+you stop adding projects.
+
+The architecture below avoids all of that. It splits the work cleanly:
+
+- **Each project owns its own build.** It compiles itself to a
+  web-deployable artifact and publishes that artifact to a stable URL.
+- **The personal site owns discovery and rendering.** It enumerates
+  repos by GitHub topic, fetches a manifest from each, validates the
+  manifest, and renders one page per project. Pages mount a small embed
+  component that loads the artifact at the URL the manifest declared.
+
+There are no submodules. The personal site never imports project source.
+Adding a new project to the site is a self-service action that lives
+entirely inside the project's own repo.
+
+## The contract
+
+Every embeddable project repo has one file at the repo root:
+
+```json
+{
+  "schemaVersion": 1,
+  "slug": "my-project",
+  "category": { "kind": "side", "year": 2025 },
+  "title": "My project",
+  "description": "What it does in one sentence.",
+  "tags": ["wasm", "graphics"],
+  "completionLevel": "works",
+
+  "embed": {
+    "kind": "wasm-emscripten",
+    "entry": "main.js"
+  },
+
+  "delivery": {
+    "mode": "runtime-r2",
+    "url": "https://assets.your-domain/my-project/abc1234/",
+    "version": "abc1234",
+    "sizeBytes": 412800
+  },
+
+  "build": {
+    "ci": true
+  }
+}
+```
+
+That's the whole interface between a project and the personal site. The
+manifest declares:
+
+- A globally-unique URL slug.
+- Some metadata for the card and listing pages.
+- An `embed.kind` that tells the site **how** to render the project.
+- A `delivery` block that tells the site **when** to acquire the
+  artifact and **where** it's served from.
+
+The site's renderer is a discriminated union on `embed.kind`. There's a
+React component per kind. The component takes one prop — the URL of the
+artifact — and knows how to mount it. That's all.
+
+## The kinds
+
+I started by listing every project I might want to embed and asking
+"what does it take to run this in a browser tab?" Eight categories cover
+essentially everything I've ever built, and probably everything you've
+ever built too:
+
+```
+static-html        →  it's already a web app, just iframe it
+wasm-emscripten    →  C/C++ via emcc, mounted via <script>
+wasm-rust          →  Rust via wasm-pack, mounted via <script>
+pyodide            →  Python in the browser via Pyodide
+notebook-html      →  Jupyter rendered to HTML, iframed
+pglite-db          →  Postgres in WASM via PGlite, schema preloaded
+tex-pdf            →  LaTeX writeup rendered to PDF, viewed via PDF.js
+external-app       →  needs a real server; iframe a deployed URL
+```
+
+The first three handle anything that runs in the browser without a
+runtime: native code, Rust, plain web apps. `pyodide` handles the
+narrower band of Python projects light enough to run client-side — game
+agents, simulators, classical-ML scoring functions. `notebook-html`
+handles every "I have a Jupyter notebook" deliverable as a read-only
+view. `pglite-db` handles database projects: a recent ElectricSQL
+release ships a full Postgres compiled to WASM, including PostGIS, that
+runs entirely in the browser tab. You bundle a `schema.sql` and an
+optional `seed.sql`, and you give the visitor a working query editor
+without ever shipping a server.
+
+`tex-pdf` is the lazy-but-honest path for LaTeX-only projects: a proof
+or paper isn't interactive in any meaningful sense, but rendering it
+inline as a PDF beside everything else lets you treat theory work as a
+first-class portfolio entry instead of an afterthought.
+
+`external-app` is the escape hatch. Some projects need a real server: a
+big ML model, a real database, anything stateful across users. The
+project deploys itself to whatever runtime makes sense — Fly, Railway,
+Modal, your own infra — and the manifest's URL points at the deployed
+app. The site iframes it.
+
+Adding a ninth kind is a 30-line PR: extend the discriminated union,
+write a renderer component, register it.
+
+## Three ways to deliver an artifact
+
+The first cut of this architecture had only one delivery path — push to
+GitHub Pages, fetch at view time. That was a mistake. Hosting and
+acquisition timing are two independent decisions, and hardcoding them
+together rules out cases where a different combination is obviously
+better. The cleaner model has three modes, picked per project:
+
+| Mode | Acquired | Served from | Best for |
+|---|---|---|---|
+| `bundle` | site CI at build time | same origin (`your-site.com/projects/<slug>/`) | small artifacts, fully-offline pages |
+| `runtime-r2` ⭐ | visitor at view time | object storage on a subdomain you control | almost everything |
+| `runtime-foreign` | visitor at view time | wherever the project hosts itself | projects that already have a live deployment |
+
+**Bundle mode** is the simplest case. The site's prebuild step fetches
+each bundle-mode project's artifact once, copies it into the site's own
+`dist/projects/<slug>/`, and rewrites the manifest's URL to a same-origin
+path. The artifact ships with the page — no runtime fetch, no CORS,
+trivially cacheable, and it works even if every external host is down.
+The cost is that the artifact counts against your site's static-asset
+quota; on Cloudflare Workers, you want individual bundles under about a
+megabyte before this becomes a problem.
+
+**Runtime-r2 mode** is the default I'd reach for. Object storage on a
+subdomain of the site's apex (`assets.your-domain`) gets you a single,
+clean origin for every project's artifacts, free egress on Cloudflare
+R2, versioned URL paths (`<slug>/<git-sha>/`), and zero per-project
+hosting setup. The project's CI uploads to R2 via the S3-compatible API
+using credentials you store as **GitHub organization secrets** so any
+project can use them without per-repo config. Atomic rollback is a
+one-line manifest edit pointing at a previous SHA.
+
+**Runtime-foreign mode** is the escape hatch. Some projects already have
+a live deployment — a Worker, a Fly app, a long-standing GitHub Pages
+site you set up years ago. There's no point in mirroring that into your
+asset bucket; the manifest just points at the existing URL. Pair this
+mode with the `external-app` embed kind for anything that needs a real
+server, or with `static-html` for an existing static deployment.
+
+The renderer components don't know or care which mode is in play. They
+take a URL prop and load from it. The mode is a delivery concern, not a
+rendering concern.
+
+> **Why object storage over per-repo GitHub Pages?** Pages is tempting
+> because it's free and zero-setup, but it splits artifact hosting across
+> `*.github.io` URLs you don't control, has no per-version path
+> convention, and adds a third-party origin to the trust boundary. R2
+> with a custom subdomain on the same eTLD+1 as the site is cleaner
+> end-to-end, gives you free egress, and lets you put one CORS rule on
+> one bucket instead of N. Pages still has its place — it's the right
+> answer for `runtime-foreign` when a project already deploys there.
+
+## Setting up the asset bucket once
+
+Whichever object store you pick (R2, S3, B2, anything S3-compatible),
+the setup is one-time and shared across every project:
+
+1. Create a bucket. One.
+2. Attach a custom domain (`assets.your-domain`).
+3. Add a CORS rule whitelisting your site's domains and `localhost`.
+4. Generate a scoped API token, save the credentials as **organization
+   secrets** in GitHub so any project repo can use them.
+5. Test once with a hello-world upload. Confirm CORS, confirm the URL
+   shape.
+
+Then every project's CI is a 10-line caller that invokes a reusable
+upload step. The bucket convention is `<slug>/<git-sha>/`, never
+`<slug>/` directly — versioned paths make rollback a single-line
+manifest edit, and they make concurrent pushes from the same project
+race-free.
+
+## The discovery flow
+
+The discovery code is a single TypeScript file in the personal site's
+prebuild step:
+
+```ts
+// roughly
+const repos = await listReposWithTopic('your-embed-topic')
+for (const repo of repos) {
+  const manifest = await fetchRawJSON(repo, 'web.codeseys.json')
+  const parsed = ProjectManifest.safeParse(manifest)
+  if (!parsed.success) {
+    log('skipping', repo, parsed.error)
+    continue
+  }
+
+  if (parsed.data.delivery.mode === 'bundle') {
+    await fetchAndStage(parsed.data.delivery.url, `dist/projects/${parsed.data.slug}/`)
+    parsed.data.delivery.url = `/projects/${parsed.data.slug}/`  // rewrite to same-origin
+  }
+
+  await writeContentEntry(parsed.data)
+}
+```
+
+The personal site lists repos by GitHub topic, fetches each manifest
+from `raw.githubusercontent.com`, validates with zod, optionally
+copies bundle-mode artifacts into the site's own `dist/`, and writes one
+JSON file per project into `src/content/projects/`. From there, the
+content collection takes over: the listing page renders cards, and the
+slug page renders a single project with its embed.
+
+A failed manifest never breaks the build. If your project's JSON has a
+typo, the site still deploys; that one project just doesn't appear
+until the next push. This matters: you do not want a typo in a side
+project to take down your blog.
+
+```mermaid
+flowchart LR
+  GH[GitHub: repos with embed topic] -->|list| S[sync-project-manifests.ts]
+  S -->|fetch web.codeseys.json| S
+  S -->|validate| S
+  S -->|if bundle: fetch + stage to dist/| S
+  S -->|write| C[content collection: projects]
+  C --> L[/projects index page/]
+  C --> P[/projects/slug page/]
+  P --> R[EmbedRouter]
+  R --> W[WasmEmbed]
+  R --> I[IframeEmbed]
+  R --> N[NotebookEmbed]
+  R --> D[PGliteEmbed]
+  R --> Y[PyodideEmbed]
+  W -.fetch artifact.-> URL[same-origin / R2 / external]
+  I -.iframe.-> URL
+  N -.iframe.-> URL
+  D -.fetch SQL.-> URL
+  Y -.fetch py + pyodide.-> URL
+```
+
+## Private projects, public artifacts
+
+Some of your projects can't be public — internship code, a course where
+the instructor prohibits publishing solutions, anything still under
+embargo. The architecture handles this cleanly because **the personal
+site only needs the artifact to be reachable, not the source.**
+
+The clean path: the private repo's CI uses the same shared org-secret
+credentials to upload its built artifact to the asset bucket. The
+bucket is public; the source repo stays private. The personal site
+fetches from the bucket without ever needing GitHub auth. Visitors can
+use the project but can't read the code.
+
+This is the legally safest path for coursework too. A visitor can play
+with a homework-derived calculator but can't fork its source and submit
+it as their own.
+
+## Reusable CI
+
+Each `embed.kind` has the same build pipeline every time. C++ to WASM
+is always the same emcc invocation. Notebook to HTML is always the same
+nbconvert. Rust to WASM is always the same wasm-pack. Each pipeline ends
+with the same R2 upload step. So those pipelines live as **reusable
+workflows** in a shared repo, and each project's CI is a 10-line caller:
+
+```yaml
+name: build web embed
+on:
+  push: { branches: [main] }
+  workflow_dispatch:
+jobs:
+  build:
+    uses: my-org/web-embed-workflows/.github/workflows/wasm-emscripten.yml@main
+    with:
+      manifest: web.codeseys.json
+    secrets: inherit  # picks up the R2_* org secrets
+```
+
+Five reusable workflows cover all eight kinds (a couple share a
+workflow). Adding a new project means picking the right workflow,
+filling in inputs, done.
+
+## What the personal site has to ship once
+
+To support all of this, the personal site needs:
+
+- A zod schema for the manifest (one file).
+- A discovery script that runs in prebuild (one file).
+- A content collection definition for projects (a few lines).
+- A listing page at `/projects` (one Astro page).
+- A slug page at `/projects/[slug]` (one Astro page).
+- An `<EmbedRouter>` component that switches on `kind` (one file).
+- One renderer component per kind, each small (~50 lines for the
+  iframe-based ones, ~100 lines for the WASM and PGlite ones).
+- A scheduled garbage-collection job that prunes unreferenced
+  R2 objects older than some retention window.
+
+All in, you're looking at well under a thousand lines of site code. The
+heavy lifting is delegated to the projects. That's the point: the site
+is a **directory and renderer**, not a build system.
+
+The site code is also language- and framework-agnostic in spirit. I run
+this on Astro + Cloudflare Workers because that's what the site
+already is, but the same architecture works on Next.js, on a static
+site, on anything that can fetch JSON at build time and ship a few
+React components.
+
+## What it costs to add a new project
+
+Once the architecture is in place, the marginal cost of making a new
+project interactable on your site is:
+
+1. Pick the embed kind (5 minutes).
+2. Pick the delivery mode (5 seconds — it's almost always `runtime-r2`).
+3. Author the manifest (10 minutes).
+4. Add a CI workflow that calls the right reusable workflow (5 minutes).
+5. Verify the artifact at the public URL (a CI run).
+6. Add the discovery topic to the repo (one click).
+
+Twenty minutes plus CI time. No personal-site PR. No coordination. The
+next time the site rebuilds, your project is there.
+
+## Why this matters
+
+The reason most personal sites stay at "list of projects with a link to
+GitHub" is that going one step further is high-friction every time.
+"Just put it on the site" rounds up to a day of work per project, and
+that day fights for time with whatever you actually want to build.
+
+The architecture above is a one-time investment that **changes the
+gradient**. Embedding a project is now lower-friction than writing the
+README. So you do it. So your site has live, runnable versions of
+everything you've ever shipped. So a recruiter or a friend or a
+random visitor doesn't have to take your word that the thing works —
+they can use it, in their tab, right now.
+
+That's the threshold worth aiming for: a portfolio that **proves
+itself**.
+
+## Caveats
+
+A few things worth saying out loud:
+
+- WebAssembly memory limits are real. A model that needs 4 GB of RAM
+  isn't going to run in `wasm32`. That's what `external-app` is for.
+- Pyodide's startup is slow (a couple of seconds) and the wheel
+  ecosystem isn't as broad as native Python. Use it for clean
+  Python-only code; don't try to embed projects that depend on Cython
+  extensions or GPU libraries.
+- Notebook-as-HTML is **read-only**. If interactivity is critical to
+  the project, you need to push the logic into one of the other kinds.
+- Cloudflare Workers' bundle limit is genuinely tight on the free
+  plan. Keep the site itself lean — runtime-mode embeds load *external*
+  artifacts at view time and only the small renderer components live in
+  the bundle. Bundle-mode artifacts go into the site's static-asset
+  quota, so reserve that mode for genuinely small payloads.
+- Slugs are forever. Once a project has a public slug, breaking that
+  URL breaks anyone who linked to it. Add aliases instead of renaming.
+- Don't open the asset bucket's CORS rule to `*`. Whitelist your site's
+  domains and `localhost`. The bucket exists to feed your embeds, not
+  to be a free CDN for the public internet.
+
+## What's next
+
+In a follow-up post I'll walk through the first project I shipped on
+this pipeline end-to-end — the manifest, the workflow, the WASM glue,
+the embed renderer, the R2 upload — so the architecture stops being
+theoretical and starts being a worked example. The code's already there
+waiting; the post is the easy part.
+
+If you want to do this on your own site, the whole thing is small enough
+that an afternoon gets you the schema, the discovery script, and the
+first two embed kinds. The remaining kinds are a steady weekly drip
+after that, as you find projects you actually want to embed.
+
+The site stops being a list of links. It starts being a place where
+work lives.

--- a/src/content/blog/build-anything-make-it-playable-an-architecture-for-discoverable-project-embeds.mdx
+++ b/src/content/blog/build-anything-make-it-playable-an-architecture-for-discoverable-project-embeds.mdx
@@ -7,8 +7,6 @@ draft: false
 featured: true
 ---
 
-import { Image } from 'astro:assets'
-
 A personal site that lists projects is fine. A personal site where you can
 **actually use the projects** — type input into a compiler, query a
 database in the browser, play against an old game-playing agent, watch a


### PR DESCRIPTION
Adds the canonical reference for making projects interactable on codeseys.io without bundling project source into this repo.

## What ships in this PR

- **`docs/PROJECT_EMBEDS.md`** — the contract. Read this before adding any new embeddable project.
  - Manifest schema (`web.codeseys.json`)
  - Eight embed kinds: `static-html`, `wasm-emscripten`, `wasm-rust`, `pyodide`, `notebook-html`, `pglite-db`, `tex-pdf`, `external-app`
  - Three delivery modes: `bundle` (build-time, same-origin), `runtime-r2` (default ⭐, served from `assets-r2.codeseys.io`), `runtime-foreign` (escape hatch for projects with their own deployment)
  - One-time setup for `assets-r2.codeseys.io`: R2 bucket, custom domain, CORS rule, GitHub org secrets
  - Versioning (`<slug>/<git-sha>/`), GC convention, end-to-end checklist
- **`src/content/blog/build-anything-make-it-playable-...mdx`** — public-facing companion essay. Project-agnostic; safe to publish.

## Why this design

- Each project owns its own build → site CI never compiles project source.
- Site only owns discovery + rendering → adding a project = self-service in that project's repo.
- No submodules, no monorepo build, no Worker-bundle bloat.
- Private repos can publish public artifacts; only the behavior leaks, not the source.
- Bundle/runtime/foreign delivery is per-project, not architectural.

## What's NOT in this PR

This is documentation only. The implementation (zod schema, discovery script, R2 setup, reusable CI workflows, embed renderer components) follows in subsequent PRs once we pilot the first project.

## Verification

- [x] `docs/PROJECT_EMBEDS.md` written
- [x] Blog post frontmatter matches `src/content.config.ts` schema (title, description, publishedAt, tags, draft, featured)
- [x] Blog post is project-agnostic — no specific project names
- [ ] `bun run astro check` — skipped (timed out on slow disk; non-blocking, the post follows the same shape as existing MDX posts)
- [ ] Visual review on Cloudflare PR preview deploy