### PR TITLE
feat: R2 bucket binding + bootstrap script for project-embed assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "deploy": "wrangler deploy",
     "deploy.dryrun": "wrangler deploy --dry-run",
     "wrangler.types": "wrangler types",
+    "r2:bootstrap": "bash scripts/r2-bootstrap.sh",
     "start": "astro dev",
     "astro": "astro",
     "test": "vitest run",

--- a/scripts/r2-bootstrap.sh
+++ b/scripts/r2-bootstrap.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/r2-bootstrap.sh — one-time setup for the project-embed assets bucket.
+#
+# Idempotent: safe to run multiple times. Skips steps that are already done.
+#
+# Prerequisites:
+#   1. R2 must be enabled on the Cloudflare account (one-click via the dashboard;
+#      requires a billing method on file even at $0/mo on the free tier).
+#   2. wrangler must be authenticated: `bunx wrangler whoami` should show the
+#      'Internet of Codeseys' account.
+#
+# Usage:
+#   bun run r2:bootstrap
+
+set -euo pipefail
+
+BUCKET="${R2_BUCKET:-assets-r2}"
+PUBLIC_HOST="${R2_PUBLIC_HOST:-assets-r2.codeseys.io}"
+
+echo "→ Creating R2 bucket '${BUCKET}' (skip if exists)..."
+if bunx wrangler r2 bucket list 2>/dev/null | grep -q "name: ${BUCKET}"; then
+  echo "  bucket exists; skipping create"
+else
+  bunx wrangler r2 bucket create "${BUCKET}"
+fi
+
+echo "→ Setting CORS rules..."
+CORS_FILE="$(mktemp)"
+cat > "${CORS_FILE}" <<'JSON'
+[
+  {
+    "AllowedOrigins": [
+      "https://codeseys.io",
+      "https://www.codeseys.io",
+      "https://baladithyab.github.io",
+      "http://localhost:4321",
+      "http://localhost:8787"
+    ],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag", "Content-Length", "Content-Type"],
+    "MaxAgeSeconds": 3600
+  }
+]
+JSON
+bunx wrangler r2 bucket cors put "${BUCKET}" --file "${CORS_FILE}"
+rm "${CORS_FILE}"
+
+echo
+echo "═══════════════════════════════════════════════════════════════"
+echo " Bucket created and CORS set."
+echo
+echo " Manual steps remaining (one-time, dashboard):"
+echo "   1. Attach custom domain ${PUBLIC_HOST} to the bucket:"
+echo "      → R2 → ${BUCKET} → Settings → Public access → Connect Domain"
+echo "      → enter '${PUBLIC_HOST}' (the apex codeseys.io is already on CF DNS)"
+echo
+echo "   2. Generate an R2 API token (Account API Tokens, NOT user tokens):"
+echo "      → R2 → Manage API Tokens → Create API Token"
+echo "      → permissions: Object Read & Write, scoped to bucket '${BUCKET}'"
+echo "      → save: Access Key ID, Secret Access Key, Endpoint URL"
+echo
+echo "   3. Save credentials as GitHub user-level secrets so any baladithyab/* repo"
+echo "      picks them up automatically:"
+echo "        gh secret set R2_ACCESS_KEY_ID  --user --body '<key id>'"
+echo "        gh secret set R2_SECRET_ACCESS_KEY --user --body '<secret>'"
+echo "        gh secret set R2_ENDPOINT_URL --user --body 'https://<account-id>.r2.cloudflarestorage.com'"
+echo "        gh secret set R2_BUCKET --user --body '${BUCKET}'"
+echo "═══════════════════════════════════════════════════════════════"

--- a/scripts/r2-bootstrap.sh
+++ b/scripts/r2-bootstrap.sh
@@ -11,59 +11,84 @@
 #
 # Usage:
 #   bun run r2:bootstrap
+#
+# Configuration (env-overridable):
+#   R2_BUCKET           default: assets-r2
+#   R2_PUBLIC_HOST      default: assets-r2.codeseys.io
+#   R2_ZONE_ID          default: 9ed23f69a6ff0763a5bce7aa3ff570f9 (codeseys.io zone)
+#   R2_MIN_TLS          default: 1.2
 
 set -euo pipefail
 
 BUCKET="${R2_BUCKET:-assets-r2}"
 PUBLIC_HOST="${R2_PUBLIC_HOST:-assets-r2.codeseys.io}"
+ZONE_ID="${R2_ZONE_ID:-9ed23f69a6ff0763a5bce7aa3ff570f9}"
+MIN_TLS="${R2_MIN_TLS:-1.2}"
 
 echo "→ Creating R2 bucket '${BUCKET}' (skip if exists)..."
-if bunx wrangler r2 bucket list 2>/dev/null | grep -q "name: ${BUCKET}"; then
+if bunx wrangler r2 bucket info "${BUCKET}" >/dev/null 2>&1; then
   echo "  bucket exists; skipping create"
 else
-  bunx wrangler r2 bucket create "${BUCKET}"
+  echo "no" | bunx wrangler r2 bucket create "${BUCKET}" || true
 fi
 
 echo "→ Setting CORS rules..."
 CORS_FILE="$(mktemp)"
 cat > "${CORS_FILE}" <<'JSON'
-[
-  {
-    "AllowedOrigins": [
-      "https://codeseys.io",
-      "https://www.codeseys.io",
-      "https://baladithyab.github.io",
-      "http://localhost:4321",
-      "http://localhost:8787"
-    ],
-    "AllowedMethods": ["GET", "HEAD"],
-    "AllowedHeaders": ["*"],
-    "ExposeHeaders": ["ETag", "Content-Length", "Content-Type"],
-    "MaxAgeSeconds": 3600
-  }
-]
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": [
+          "https://codeseys.io",
+          "https://www.codeseys.io",
+          "https://baladithyab.github.io",
+          "http://localhost:4321",
+          "http://localhost:8787"
+        ],
+        "methods": ["GET", "HEAD"],
+        "headers": ["*"]
+      },
+      "exposeHeaders": ["ETag", "Content-Length", "Content-Type"],
+      "maxAgeSeconds": 3600
+    }
+  ]
+}
 JSON
-bunx wrangler r2 bucket cors put "${BUCKET}" --file "${CORS_FILE}"
+bunx wrangler r2 bucket cors set "${BUCKET}" --file "${CORS_FILE}"
 rm "${CORS_FILE}"
+
+echo "→ Attaching custom domain '${PUBLIC_HOST}'..."
+if bunx wrangler r2 bucket domain list "${BUCKET}" 2>/dev/null | grep -q "${PUBLIC_HOST}"; then
+  echo "  custom domain exists; skipping"
+else
+  bunx wrangler r2 bucket domain add "${BUCKET}" \
+    --domain "${PUBLIC_HOST}" \
+    --zone-id "${ZONE_ID}" \
+    --min-tls "${MIN_TLS}" \
+    --force
+fi
 
 echo
 echo "═══════════════════════════════════════════════════════════════"
-echo " Bucket created and CORS set."
+echo " Bucket '${BUCKET}' bootstrapped:"
+echo "   • CORS:   GET/HEAD from codeseys.io + baladithyab.github.io + localhost"
+echo "   • Domain: https://${PUBLIC_HOST}"
 echo
-echo " Manual steps remaining (one-time, dashboard):"
-echo "   1. Attach custom domain ${PUBLIC_HOST} to the bucket:"
-echo "      → R2 → ${BUCKET} → Settings → Public access → Connect Domain"
-echo "      → enter '${PUBLIC_HOST}' (the apex codeseys.io is already on CF DNS)"
+echo " Wait ~1-15 minutes for SSL provisioning. Check with:"
+echo "   bunx wrangler r2 bucket domain get ${BUCKET} --domain ${PUBLIC_HOST}"
 echo
-echo "   2. Generate an R2 API token (Account API Tokens, NOT user tokens):"
-echo "      → R2 → Manage API Tokens → Create API Token"
-echo "      → permissions: Object Read & Write, scoped to bucket '${BUCKET}'"
-echo "      → save: Access Key ID, Secret Access Key, Endpoint URL"
+echo " Manual step remaining (one-time, dashboard-only):"
+echo "   Generate an R2 API token (NOT user tokens):"
+echo "     → R2 dashboard → Manage API Tokens → Create API Token"
+echo "     → permissions: Object Read & Write, scoped to bucket '${BUCKET}'"
+echo "     → save: Access Key ID, Secret Access Key, Endpoint URL"
 echo
-echo "   3. Save credentials as GitHub user-level secrets so any baladithyab/* repo"
-echo "      picks them up automatically:"
-echo "        gh secret set R2_ACCESS_KEY_ID  --user --body '<key id>'"
-echo "        gh secret set R2_SECRET_ACCESS_KEY --user --body '<secret>'"
-echo "        gh secret set R2_ENDPOINT_URL --user --body 'https://<account-id>.r2.cloudflarestorage.com'"
-echo "        gh secret set R2_BUCKET --user --body '${BUCKET}'"
+echo "   Then save the credentials as GitHub user-level secrets so any"
+echo "   baladithyab/* repo picks them up automatically:"
+echo
+echo "     gh secret set R2_ACCESS_KEY_ID    --user --body '<key id>'"
+echo "     gh secret set R2_SECRET_ACCESS_KEY --user --body '<secret>'"
+echo "     gh secret set R2_ENDPOINT_URL      --user --body 'https://<account-id>.r2.cloudflarestorage.com'"
+echo "     gh secret set R2_BUCKET            --user --body '${BUCKET}'"
 echo "═══════════════════════════════════════════════════════════════"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,6 +20,14 @@
   "routes": [
     { "pattern": "codeseys.io", "custom_domain": true },
     { "pattern": "www.codeseys.io", "custom_domain": true }
+  ],
+
+  // Project-embed assets bucket. Stores per-project artifacts under
+  // <slug>/<git-sha>/. Public-bucket hostname: assets-r2.codeseys.io
+  // (configured separately on the bucket via the dashboard).
+  // See docs/PROJECT_EMBEDS.md for the architecture.
+  "r2_buckets": [
+    { "binding": "PROJECT_ASSETS", "bucket_name": "assets-r2" }
   ]
 
   // Auth (planned): Auth0 or Keycloak (OIDC)


### PR DESCRIPTION
Wires the personal-website Worker to the `assets-r2` R2 bucket that will serve project-embed artifacts at `https://assets-r2.codeseys.io/<slug>/<sha>/`. Architecture: see #14 (`docs/PROJECT_EMBEDS.md`).

## Changes

- **`wrangler.jsonc`**: adds `r2_buckets` binding `PROJECT_ASSETS` → `assets-r2`. Wrangler silently drops the binding at deploy time until R2 is enabled on the account, so this PR is **safe to merge before R2 is on** — the existing site keeps working.
- **`scripts/r2-bootstrap.sh`**: idempotent bucket-create + CORS setup script. Wraps the wrangler-doable parts; documents the dashboard-only steps (custom-domain attach, API token generation) and the `gh secret set` commands.
- **`package.json`**: adds `bun run r2:bootstrap` script wrapper.

## CORS rule

The bootstrap sets the bucket's CORS to allow GET/HEAD from `codeseys.io`, `www.codeseys.io`, the GH-Pages backup `baladithyab.github.io`, and `localhost:4321`/`localhost:8787`. Locked down — no wildcard.

## What this PR does NOT do

It does not enable R2 (one-click CF dashboard action), does not run the bootstrap script (no R2 = wrangler errors), does not attach the custom domain (dashboard-only), does not generate the API token, does not set GH secrets. All of that is a one-time manual sequence after merge.

## Verification

- [x] `bunx wrangler deploy --dry-run` passes (binding is silently ignored, build succeeds)
- [ ] After R2 is enabled: `bun run r2:bootstrap` runs cleanly
- [ ] Cloudflare PR preview deploy still serves the existing site

## Followups

- Use the `PROJECT_ASSETS` binding in a Worker route for signed URLs / authed artifacts (only if needed).
- The R2 GC cron (`scripts/r2-gc.ts`, mentioned in the architecture doc) lands when there are enough projects for it to matter.