### PR TITLE
feat(embed): /api/embed-upload Worker route + R2 binding-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 # generated types
 .astro/
+worker-configuration.d.ts
 .vscode/
 .wrangler/
 appmap/

--- a/src/lib/embed-upload.test.ts
+++ b/src/lib/embed-upload.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildKey,
+  checkBearer,
+  contentTypeForPath,
+  isSafeRelativePath,
+  SLUG_RE,
+  timingSafeEqual,
+  VERSION_RE,
+} from './embed-upload'
+
+describe('SLUG_RE', () => {
+  it.each([
+    ['cse-160-asg2', true],
+    ['a', true],
+    ['my-project-123', true],
+    ['ABC', false],
+    ['has spaces', false],
+    ['has_underscore', false],
+    ['', false],
+    ['-leading-hyphen', false],
+    ['x'.repeat(65), false],
+  ])('matches %s -> %s', (input, expected) => {
+    expect(SLUG_RE.test(input)).toBe(expected)
+  })
+})
+
+describe('VERSION_RE', () => {
+  it.each([
+    ['abc1234', true],
+    ['v1.2.3', true],
+    ['main-2026-05-27', true],
+    ['staging', true],
+    ['has space', false],
+    ['has/slash', false],
+    ['', false],
+    ['x'.repeat(41), false],
+  ])('matches %s -> %s', (input, expected) => {
+    expect(VERSION_RE.test(input)).toBe(expected)
+  })
+})
+
+describe('isSafeRelativePath', () => {
+  it.each([
+    ['index.html', true],
+    ['lib/cuon-matrix.js', true],
+    ['assets/sky.jpg', true],
+    ['', false],
+    ['/abs', false],
+    ['./relative', false],
+    ['..', false],
+    ['../escape', false],
+    ['nested/../escape', false],
+    ['back\\slash', false],
+    ['has\u0000null', false],
+    ['x'.repeat(257), false],
+  ])('checks %s -> %s', (input, expected) => {
+    expect(isSafeRelativePath(input)).toBe(expected)
+  })
+})
+
+describe('timingSafeEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(timingSafeEqual('abc', 'abc')).toBe(true)
+  })
+  it('returns false for different strings', () => {
+    expect(timingSafeEqual('abc', 'abd')).toBe(false)
+  })
+  it('returns false for different-length strings', () => {
+    expect(timingSafeEqual('abc', 'abcd')).toBe(false)
+  })
+  it('handles empty strings', () => {
+    expect(timingSafeEqual('', '')).toBe(true)
+  })
+})
+
+describe('checkBearer', () => {
+  it('returns 503 when token unconfigured', () => {
+    const r = checkBearer('Bearer x', undefined)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.status).toBe(503)
+  })
+  it('returns 401 with no header', () => {
+    const r = checkBearer(null, 'secret')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.status).toBe(401)
+  })
+  it('returns 401 without Bearer prefix', () => {
+    const r = checkBearer('Token secret', 'secret')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.status).toBe(401)
+  })
+  it('returns 401 on mismatch', () => {
+    const r = checkBearer('Bearer wrong', 'secret')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.status).toBe(401)
+  })
+  it('returns ok on match', () => {
+    const r = checkBearer('Bearer secret', 'secret')
+    expect(r.ok).toBe(true)
+  })
+  it('tolerates trailing whitespace in header', () => {
+    const r = checkBearer('Bearer secret  ', 'secret')
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe('buildKey', () => {
+  it('joins slug, version, and path', () => {
+    expect(buildKey('cse-160', 'abc1234', 'asg2.html')).toBe('cse-160/abc1234/asg2.html')
+  })
+  it('handles nested paths', () => {
+    expect(buildKey('cse-160', 'abc1234', 'lib/foo.js')).toBe('cse-160/abc1234/lib/foo.js')
+  })
+})
+
+describe('contentTypeForPath', () => {
+  it.each([
+    ['index.html', 'text/html; charset=utf-8'],
+    ['main.js', 'application/javascript; charset=utf-8'],
+    ['app.wasm', 'application/wasm'],
+    ['style.css', 'text/css; charset=utf-8'],
+    ['photo.png', 'image/png'],
+    ['video.mp4', 'video/mp4'],
+    ['unknown', 'application/octet-stream'],
+    ['UPPER.HTML', 'text/html; charset=utf-8'],
+  ])('maps %s -> %s', (input, expected) => {
+    expect(contentTypeForPath(input)).toBe(expected)
+  })
+})

--- a/src/lib/embed-upload.ts
+++ b/src/lib/embed-upload.ts
@@ -1,0 +1,115 @@
+/**
+ * Project-embed asset upload helpers.
+ *
+ * Server-side validation + R2 binding interaction for the
+ * `/api/embed-upload` endpoint. Lives in `src/lib/` so it can be unit-tested
+ * without spinning up an Astro request.
+ *
+ * Auth model: a single shared bearer token (`PROJECT_EMBED_UPLOAD_TOKEN`)
+ * is kept as a Cloudflare Worker secret. CI workflows that build project
+ * artifacts authenticate with that token. The bucket itself never needs
+ * S3-compatible API keys — the Worker holds the R2 binding and is the
+ * sole writer.
+ */
+
+export type EmbedUploadEnv = {
+  PROJECT_ASSETS?: R2Bucket
+  PROJECT_EMBED_UPLOAD_TOKEN?: string
+}
+
+// Slug pattern matches the project-manifest schema: lowercase alnum + hyphens.
+// Length-bounded to keep keys reasonable.
+export const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/
+
+// Version is normally a short git SHA (7-12 hex chars), but we also allow
+// 'staging' / 'preview' / explicit semver-like tags so manual uploads work.
+export const VERSION_RE = /^[a-zA-Z0-9._-]{1,40}$/
+
+// Path inside the artifact tree. Disallows `..` segments, leading `/`,
+// backslashes, control chars, and anything > 256 chars.
+export function isSafeRelativePath(p: string): boolean {
+  if (p.length === 0 || p.length > 256) return false
+  if (p.startsWith('/') || p.startsWith('./')) return false
+  if (p.includes('\\')) return false
+  if (p.includes('..')) return false
+  for (let i = 0; i < p.length; i++) {
+    const code = p.charCodeAt(i)
+    if (code < 0x20 || code === 0x7f) return false
+  }
+  return true
+}
+
+/** Constant-time bearer comparison so we don't leak secrets through timing. */
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}
+
+export type AuthResult =
+  | { ok: true }
+  | { ok: false; status: 401 | 503; message: string }
+
+export function checkBearer(
+  authHeader: string | null,
+  expectedToken: string | undefined
+): AuthResult {
+  if (!expectedToken) {
+    return {
+      ok: false,
+      status: 503,
+      message: 'PROJECT_EMBED_UPLOAD_TOKEN is not configured on the Worker',
+    }
+  }
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { ok: false, status: 401, message: 'Missing Bearer token' }
+  }
+  const presented = authHeader.slice('Bearer '.length).trim()
+  if (!timingSafeEqual(presented, expectedToken)) {
+    return { ok: false, status: 401, message: 'Invalid Bearer token' }
+  }
+  return { ok: true }
+}
+
+/** Build the R2 object key from manifest-derived components. */
+export function buildKey(slug: string, version: string, path: string): string {
+  return `${slug}/${version}/${path}`
+}
+
+const CONTENT_TYPE_BY_EXT: Record<string, string> = {
+  html: 'text/html; charset=utf-8',
+  htm: 'text/html; charset=utf-8',
+  js: 'application/javascript; charset=utf-8',
+  mjs: 'application/javascript; charset=utf-8',
+  css: 'text/css; charset=utf-8',
+  json: 'application/json; charset=utf-8',
+  wasm: 'application/wasm',
+  svg: 'image/svg+xml',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+  gif: 'image/gif',
+  ico: 'image/x-icon',
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  pdf: 'application/pdf',
+  txt: 'text/plain; charset=utf-8',
+  md: 'text/markdown; charset=utf-8',
+  glsl: 'text/plain; charset=utf-8',
+  vert: 'text/plain; charset=utf-8',
+  frag: 'text/plain; charset=utf-8',
+}
+
+/** Best-effort content-type from filename; falls back to octet-stream. */
+export function contentTypeForPath(path: string): string {
+  const dot = path.lastIndexOf('.')
+  if (dot === -1) return 'application/octet-stream'
+  const ext = path.slice(dot + 1).toLowerCase()
+  return CONTENT_TYPE_BY_EXT[ext] ?? 'application/octet-stream'
+}

--- a/src/pages/api/embed-upload.ts
+++ b/src/pages/api/embed-upload.ts
@@ -1,0 +1,154 @@
+/**
+ * PUT /api/embed-upload?slug=<slug>&version=<sha>&path=<rel/path>
+ *
+ * Uploads a single file into the project-embed assets bucket via the R2
+ * binding. Auth: shared bearer token (`PROJECT_EMBED_UPLOAD_TOKEN` Worker
+ * secret). Used by `baladithyab/web-embed-workflows` reusable workflows.
+ *
+ * Stored at:
+ *   r2://${PROJECT_ASSETS}/<slug>/<version>/<path>
+ *
+ * Served at:
+ *   https://assets-r2.codeseys.io/<slug>/<version>/<path>
+ *
+ * GET on this same route returns a tiny status payload so callers can
+ * health-check before pushing artifacts.
+ */
+import type { APIRoute } from 'astro'
+import { getRuntimeEnv } from '@/lib/runtime-env'
+import {
+  type EmbedUploadEnv,
+  buildKey,
+  checkBearer,
+  contentTypeForPath,
+  isSafeRelativePath,
+  SLUG_RE,
+  VERSION_RE,
+} from '@/lib/embed-upload'
+
+// Cloudflare Workers request body cap is 100 MiB; keep some headroom and
+// cap the per-file artifact size at 90 MiB. Larger artifacts should split
+// into multiple files or fall back to the (still-supported) S3-compatible
+// path described in docs/PROJECT_EMBEDS.md.
+const MAX_BYTES = 90 * 1024 * 1024
+
+function jsonResponse(body: unknown, status: number, extraHeaders: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      ...extraHeaders,
+    },
+  })
+}
+
+export const GET: APIRoute = () =>
+  jsonResponse(
+    {
+      ok: true,
+      service: 'project-embed-upload',
+      docs: 'https://github.com/baladithyab/baladithyab.github.io/blob/main/docs/PROJECT_EMBEDS.md',
+      hint: 'PUT here with ?slug=&version=&path= and Authorization: Bearer <token>',
+    },
+    200
+  )
+
+export const PUT: APIRoute = async ({ request }) => {
+  const env = getRuntimeEnv<EmbedUploadEnv>()
+
+  // Auth.
+  const auth = checkBearer(request.headers.get('Authorization'), env.PROJECT_EMBED_UPLOAD_TOKEN)
+  if (!auth.ok) {
+    return jsonResponse({ error: auth.message }, auth.status)
+  }
+
+  // Binding present?
+  if (!env.PROJECT_ASSETS) {
+    return jsonResponse(
+      {
+        error: 'PROJECT_ASSETS R2 binding is not configured on the Worker',
+        hint: 'Check wrangler.jsonc r2_buckets entry and that R2 is enabled on the account.',
+      },
+      503
+    )
+  }
+
+  // Parse and validate query params.
+  const url = new URL(request.url)
+  const slug = url.searchParams.get('slug') ?? ''
+  const version = url.searchParams.get('version') ?? ''
+  const path = url.searchParams.get('path') ?? ''
+  if (!SLUG_RE.test(slug)) {
+    return jsonResponse({ error: 'invalid slug', got: slug }, 400)
+  }
+  if (!VERSION_RE.test(version)) {
+    return jsonResponse({ error: 'invalid version', got: version }, 400)
+  }
+  if (!isSafeRelativePath(path)) {
+    return jsonResponse({ error: 'invalid path', got: path }, 400)
+  }
+
+  // Size guardrail. We try the Content-Length header first, but a missing
+  // header doesn't block the upload — R2.put() will surface its own size
+  // limits if the streamed body exceeds them.
+  const declaredLen = request.headers.get('Content-Length')
+  if (declaredLen !== null) {
+    const n = Number(declaredLen)
+    if (!Number.isFinite(n) || n < 0) {
+      return jsonResponse({ error: 'invalid Content-Length' }, 400)
+    }
+    if (n > MAX_BYTES) {
+      return jsonResponse(
+        {
+          error: 'artifact too large for binding-proxy upload',
+          declaredBytes: n,
+          maxBytes: MAX_BYTES,
+          hint: 'Split into smaller files or use the S3-compatible path.',
+        },
+        413
+      )
+    }
+  }
+
+  if (!request.body) {
+    return jsonResponse({ error: 'empty body' }, 400)
+  }
+
+  const key = buildKey(slug, version, path)
+  const httpMetadata: R2HTTPMetadata = {
+    contentType: request.headers.get('Content-Type') ?? contentTypeForPath(path),
+  }
+  const cacheControl = request.headers.get('X-Cache-Control')
+  if (cacheControl) httpMetadata.cacheControl = cacheControl
+
+  try {
+    const result = await env.PROJECT_ASSETS.put(key, request.body, { httpMetadata })
+    return jsonResponse(
+      {
+        ok: true,
+        key,
+        publicUrl: `https://assets-r2.codeseys.io/${key}`,
+        etag: result?.httpEtag ?? null,
+        size: result?.size ?? null,
+      },
+      200
+    )
+  } catch (err) {
+    return jsonResponse(
+      {
+        error: 'R2 put failed',
+        details: err instanceof Error ? err.message : String(err),
+      },
+      500
+    )
+  }
+}
+
+// Disallow other methods explicitly so attackers don't get cute.
+const reject: APIRoute = () =>
+  jsonResponse({ error: 'method not allowed' }, 405, { Allow: 'GET, PUT' })
+
+export const POST = reject
+export const DELETE = reject
+export const PATCH = reject


### PR DESCRIPTION
Adds the Worker-side upload endpoint that lets project-embed CI workflows push artifacts into R2 **without ever needing S3-compatible API keys**. Single shared bearer token authenticates CI; the Worker holds the only R2 binding.

## Why binding-proxy over S3 keys

Investigated per #14 / #15 + research on bindings:

- Bindings only work *inside* a Worker — but we own the Worker, so we can expose a thin authenticated upload route that uses the binding.
- **One secret instead of four** — `PROJECT_EMBED_UPLOAD_TOKEN` only.
- R2 access logs unify with the Worker observability we already have on (`head_sampling_rate: 1`).
- Slug allowlists, rate limits, manifest pre-validation can all live in this one file.
- Smoke-tested on the live R2 bucket (`assets-r2`) — `https://assets-r2.codeseys.io/smoke-test/index.html` returns 200.

Trade-off: the 100 MiB Worker request body cap (we use 90 MiB to leave headroom). For artifacts larger than 90 MiB single file, the architecture doc still lists S3-compatible upload as a fallback.

## What this PR adds

- `src/lib/embed-upload.ts` — pure validation + auth logic (no Astro deps).
- `src/lib/embed-upload.test.ts` — 49 unit tests covering:
  - Slug regex (lowercase alnum + hyphens, length-bounded)
  - Version regex (short SHA, semver, named tags)
  - Path safety (no `..`, abs paths, backslashes, control chars, > 256 chars)
  - Constant-time bearer comparison
  - Content-type fallback table
- `src/pages/api/embed-upload.ts` — Astro API route.
  - `GET` returns a tiny status payload so CI can health-check before pushing
  - `PUT` validates auth + params + size, calls `env.PROJECT_ASSETS.put(`${slug}/${version}/${path}`, body, { httpMetadata })`
  - All other methods return 405
- `.gitignore` — adds `worker-configuration.d.ts` (regenerated by `bunx wrangler types`)

## Endpoint shape

```
GET  /api/embed-upload                       → { ok: true, service: ... }
PUT  /api/embed-upload?slug=&version=&path=  → { ok: true, key, publicUrl, etag, size }
Other methods                                → 405
```

Stores at: `r2://assets-r2/<slug>/<version>/<path>`
Serves from: `https://assets-r2.codeseys.io/<slug>/<version>/<path>`

## Verification

- [x] `bun run test src/lib/embed-upload.test.ts` — 49/49 pass
- [x] `bun run build` — succeeds; worker-configuration.d.ts shows `PROJECT_ASSETS: R2Bucket`
- [x] `bunx wrangler deploy --dry-run` — bindings include `env.PROJECT_ASSETS (assets-r2)  R2 Bucket`
- [x] `PROJECT_EMBED_UPLOAD_TOKEN` secret already set on the production Worker (via CF API; wrangler can't run interactive in non-tty session)
- [x] Same token added as repo secret on `baladithyab/UCSC-CSE-160-W21` so its build workflow can authenticate
- [ ] After merge: trigger `baladithyab/UCSC-CSE-160-W21` workflow, watch artifact appear at `https://assets-r2.codeseys.io/cse-160-asg2/<sha>/asg2.html`

## Followups (separate PRs)

- Update `docs/PROJECT_EMBEDS.md` and the blog post to flip the recommendation to binding-proxy. The S3-compatible path stays documented as a >90 MiB fallback.
- Add tarball POST variant for whole-tree single-call uploads (current per-file PUT loop is fine for our pilot scale).
- Personal-site `/projects/[slug]` route + zod manifest schema + content collection (next major slice).