### PR TITLE
fix(security): disable Astro checkOrigin for bearer-auth APIs

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -104,6 +104,27 @@ function rehypeMermaidNormalize() {
 export default defineConfig({
   output: 'server',
   site: 'https://codeseys.io/',
+
+  // Disable Astro's built-in cross-origin form-submission check.
+  //
+  // The check rejects PUT/POST/DELETE/PATCH whose Origin header doesn't
+  // match the request URL. That breaks legitimate API clients (curl,
+  // CI workflows, server-to-server calls) that don't set Origin at all.
+  //
+  // Our APIs use bearer-token auth (`Authorization: Bearer ...`), which
+  // is inherently CSRF-immune because attackers can't read the token from
+  // a victim's browser. Cookie-based OIDC auth is currently inert, but
+  // when it lands its endpoints (`/api/auth/*`) should set explicit
+  // CSRF protection (state param + signed cookie) rather than relying on
+  // Astro's blanket origin check.
+  //
+  // See:
+  // - https://docs.astro.dev/en/reference/configuration-reference/#securitycheckorigin
+  // - docs/PROJECT_EMBEDS.md (the /api/embed-upload endpoint depends on this)
+  security: {
+    checkOrigin: false,
+  },
+
   adapter: cloudflare({
     // v13+ default: Cloudflare Images binding for runtime image transforms.
     // Astro auto-provisions an `IMAGES` binding on deploy — no manual setup


### PR DESCRIPTION
Astro 6 ships with `security.checkOrigin: true` by default which rejects PUT/POST/DELETE/PATCH whose Origin header doesn't match the request URL. That breaks every legitimate API client that doesn't set Origin: curl, CI workflows, server-to-server calls — including our `/api/embed-upload` Worker route from PR #16.

## Smoke test that surfaced this

```bash
curl -X PUT https://codeseys.io/api/embed-upload?slug=smoke&version=test&path=hello.txt \\
  -H 'Authorization: Bearer $TOKEN' \\
  --data-binary @file
# returns: HTTP 403 'Cross-site PUT form submissions are forbidden'
```

## Why it's safe to disable

Our APIs use **Bearer auth**, which is CSRF-immune by construction:
- Attackers can't read the token from a victim's browser
- The token isn't auto-attached by the browser like a cookie would be
- An attacker forging a request from another origin has no way to set the Authorization header

The OIDC auth endpoints under `/api/auth` are currently inert — when they land they should add explicit CSRF protection (signed state cookie) rather than relying on Astro's blanket origin check. Per-route disable isn't supported by Astro, so global disable is the cleanest path.

## Verification

After merge, run:
```bash
TOKEN=$(...)
curl -X PUT 'https://codeseys.io/api/embed-upload?slug=smoke&version=test&path=hello.txt' \\
  -H "Authorization: Bearer $TOKEN" --data-binary 'hello'
# expect: HTTP 200 with { ok: true, key, publicUrl, etag, size }
curl https://assets-r2.codeseys.io/smoke/test/hello.txt
# expect: 'hello'
```