### PR TITLE
fix(embed-upload): prefer extension-derived content-type for known types

### DIFF
--- a/src/pages/api/embed-upload.ts
+++ b/src/pages/api/embed-upload.ts
@@ -116,8 +116,20 @@ export const PUT: APIRoute = async ({ request }) => {
   }
 
   const key = buildKey(slug, version, path)
+
+  // Content-type policy: prefer the extension-derived type for known
+  // extensions (HTML / WASM / CSS / etc. should always be served with
+  // their canonical type, regardless of what the uploader claims). Fall
+  // back to the request's Content-Type header for unknown extensions.
+  // This keeps the system robust to clients (curl/CI) that send a
+  // generic application/octet-stream or application/x-www-form-urlencoded.
+  const derivedType = contentTypeForPath(path)
+  const headerType = request.headers.get('Content-Type')
   const httpMetadata: R2HTTPMetadata = {
-    contentType: request.headers.get('Content-Type') ?? contentTypeForPath(path),
+    contentType:
+      derivedType !== 'application/octet-stream'
+        ? derivedType
+        : (headerType ?? derivedType),
   }
   const cacheControl = request.headers.get('X-Cache-Control')
   if (cacheControl) httpMetadata.cacheControl = cacheControl


### PR DESCRIPTION
First real run of the binding-proxy upload pipeline (CSE 160 → R2) revealed that `asg2.html` got served with `content-type: application/x-www-form-urlencoded` because curl's `--data-binary` default Content-Type was passed through to R2.

New policy: for any extension we have a canonical type for (html, js, wasm, css, png, ...), the Worker uses that regardless of what the client claims. For unknown extensions we still honor the client's header.

This makes the pipeline robust to all common HTTP clients — curl, fetch, axios, AWS CLI fallback — without requiring them to set the right MIME type.