### PR TITLE
feat(profile): repo cards link to /projects/<slug> for embeddable projects

### DIFF
--- a/src/components/RepoGrid.tsx
+++ b/src/components/RepoGrid.tsx
@@ -8,7 +8,7 @@
  *   - SSR-safe relative timestamps (`just now` until hydrated).
  */
 import { useEffect, useMemo, useState } from 'react'
-import { ExternalLink, Search, Star, X } from 'lucide-react'
+import { ExternalLink, Play, Search, Star, X } from 'lucide-react'
 import type { Repo } from '@/lib/github'
 
 interface Props {
@@ -255,12 +255,22 @@ export default function RepoGrid({ repos }: Props) {
 
 function RepoCard({ repo, nowMs }: { repo: Repo; nowMs: number | undefined }) {
   const lang = repo.language ?? null
+  // When the repo backs an embeddable project, route to /projects/<slug>
+  // (in-site live demo) instead of GitHub. Same-origin link, no
+  // target=_blank — staying on the site is the whole point.
+  const isEmbed = Boolean(repo.embedSlug)
+  const href = isEmbed ? `/projects/${repo.embedSlug}` : repo.html_url
+  const linkProps = isEmbed
+    ? { 'aria-label': `Open ${repo.name} as a live demo` }
+    : { target: '_blank' as const, rel: 'noopener noreferrer' }
+
   return (
     <a
-      href={repo.html_url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex h-full flex-col gap-2.5 rounded-xl border bg-card p-3.5 transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+      href={href}
+      {...linkProps}
+      className={`group flex h-full flex-col gap-2.5 rounded-xl border bg-card p-3.5 transition-all hover:-translate-y-0.5 hover:shadow-md ${
+        isEmbed ? 'hover:border-primary/60' : 'hover:border-primary/40'
+      }`}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
@@ -268,8 +278,20 @@ function RepoCard({ repo, nowMs }: { repo: Repo; nowMs: number | undefined }) {
             <span className="truncate text-sm font-semibold leading-tight group-hover:underline">
               {repo.name}
             </span>
-            <ExternalLink className="size-3.5 shrink-0 text-muted-foreground/60 transition-colors group-hover:text-primary" />
+            {isEmbed ? (
+              <Play
+                className="size-3.5 shrink-0 fill-primary/20 text-primary transition-colors group-hover:fill-primary/40"
+                aria-hidden="true"
+              />
+            ) : (
+              <ExternalLink className="size-3.5 shrink-0 text-muted-foreground/60 transition-colors group-hover:text-primary" />
+            )}
           </div>
+          {isEmbed && (
+            <span className="mt-1 inline-flex items-center rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary">
+              Live demo
+            </span>
+          )}
         </div>
       </div>
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -16,6 +16,14 @@ export type Repo = {
   language?: string | null
   /** Stargazer count. Optional for backwards compat with older callers. */
   stars?: number
+  /**
+   * Slug of the embeddable project this repo backs, if any. When present,
+   * the repo card links to `/projects/<embedSlug>` (the live in-site demo)
+   * instead of GitHub. Populated at build time by joining `getCollection(
+   * 'projects')` against the repo's `<owner>/<name>` — see
+   * `src/lib/projects.ts::buildEmbedSlugMap`.
+   */
+  embedSlug?: string
 }
 
 export interface GitHubEnv {

--- a/src/lib/projects.test.ts
+++ b/src/lib/projects.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for src/lib/projects.ts.
+ *
+ * Pure helpers — no Astro / network needed. Verifies:
+ *   - buildEmbedSlugMap aggregates entries, lowercases the key, and
+ *     handles the duplicate-source edge case
+ *   - repoFullNameFromUrl normalises trailing slashes, .git suffixes,
+ *     and case
+ *   - annotateWithEmbedSlug returns the repo unchanged when no manifest
+ *     matches, and adds embedSlug when one does
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  annotateWithEmbedSlug,
+  buildEmbedSlugMap,
+  repoFullNameFromUrl,
+  type ProjectEntryLike,
+  type RepoLike,
+} from './projects'
+
+function entry(slug: string, source: string): ProjectEntryLike {
+  return { data: { slug, discovery: { source } } }
+}
+
+describe('repoFullNameFromUrl', () => {
+  it('extracts owner/name from a canonical github url', () => {
+    expect(repoFullNameFromUrl('https://github.com/baladithyab/UCSC-CSE-160-W21')).toBe(
+      'baladithyab/ucsc-cse-160-w21',
+    )
+  })
+
+  it('strips a trailing slash', () => {
+    expect(repoFullNameFromUrl('https://github.com/foo/bar/')).toBe('foo/bar')
+  })
+
+  it('strips a .git suffix', () => {
+    expect(repoFullNameFromUrl('https://github.com/foo/bar.git')).toBe('foo/bar')
+    expect(repoFullNameFromUrl('https://github.com/foo/bar.GIT')).toBe('foo/bar')
+  })
+
+  it('lowercases the result so case-insensitive comparison Just Works', () => {
+    expect(repoFullNameFromUrl('https://github.com/BalaDithyaB/UCSC-CSE-160-W21')).toBe(
+      'baladithyab/ucsc-cse-160-w21',
+    )
+  })
+
+  it('returns null for a profile URL (no repo)', () => {
+    expect(repoFullNameFromUrl('https://github.com/baladithyab')).toBe(null)
+  })
+
+  it('returns null for non-github hosts', () => {
+    expect(repoFullNameFromUrl('https://gitlab.com/foo/bar')).toBe(null)
+  })
+
+  it('returns null for malformed URLs', () => {
+    expect(repoFullNameFromUrl('not a url at all')).toBe(null)
+  })
+
+  it('accepts www.github.com', () => {
+    expect(repoFullNameFromUrl('https://www.github.com/foo/bar')).toBe('foo/bar')
+  })
+
+  it('ignores extra path segments after owner/name', () => {
+    expect(repoFullNameFromUrl('https://github.com/foo/bar/tree/main/src')).toBe('foo/bar')
+  })
+})
+
+describe('buildEmbedSlugMap', () => {
+  it('produces an empty map for an empty list', () => {
+    expect(buildEmbedSlugMap([])).toEqual(new Map())
+  })
+
+  it('keys by lowercase source', () => {
+    const map = buildEmbedSlugMap([entry('cse-160-asg2', 'BalaDithyaB/UCSC-CSE-160-W21')])
+    expect(map.get('baladithyab/ucsc-cse-160-w21')).toBe('cse-160-asg2')
+    expect(map.get('BalaDithyaB/UCSC-CSE-160-W21')).toBeUndefined()
+  })
+
+  it('first writer wins on duplicate sources', () => {
+    const map = buildEmbedSlugMap([
+      entry('first', 'foo/bar'),
+      entry('second', 'FOO/BAR'),
+    ])
+    expect(map.get('foo/bar')).toBe('first')
+    expect(map.size).toBe(1)
+  })
+
+  it('handles multiple distinct entries', () => {
+    const map = buildEmbedSlugMap([
+      entry('cse-160-asg2', 'baladithyab/UCSC-CSE-160-W21'),
+      entry('cse-101-bigint', 'baladithyab/UCSC-CSE-101-W22'),
+    ])
+    expect(map.size).toBe(2)
+    expect(map.get('baladithyab/ucsc-cse-160-w21')).toBe('cse-160-asg2')
+    expect(map.get('baladithyab/ucsc-cse-101-w22')).toBe('cse-101-bigint')
+  })
+})
+
+describe('annotateWithEmbedSlug', () => {
+  const slugMap = new Map<string, string>([
+    ['baladithyab/ucsc-cse-160-w21', 'cse-160-asg2'],
+  ])
+
+  it('adds embedSlug when the repo matches a manifest', () => {
+    const repo: RepoLike = {
+      name: 'UCSC-CSE-160-W21',
+      html_url: 'https://github.com/baladithyab/UCSC-CSE-160-W21',
+    }
+    const result = annotateWithEmbedSlug(repo, slugMap)
+    expect((result as RepoLike & { embedSlug?: string }).embedSlug).toBe('cse-160-asg2')
+  })
+
+  it('returns repo unchanged when no manifest matches', () => {
+    const repo: RepoLike = {
+      name: 'unrelated',
+      html_url: 'https://github.com/baladithyab/unrelated',
+    }
+    const result = annotateWithEmbedSlug(repo, slugMap)
+    expect((result as RepoLike & { embedSlug?: string }).embedSlug).toBeUndefined()
+    expect(result).toEqual(repo)
+  })
+
+  it('returns repo unchanged when html_url is unparseable', () => {
+    const repo: RepoLike = { name: 'oops', html_url: 'gibberish' }
+    expect(annotateWithEmbedSlug(repo, slugMap)).toEqual(repo)
+  })
+
+  it('preserves all other repo fields', () => {
+    const repo: RepoLike & { description: string; stars: number } = {
+      name: 'UCSC-CSE-160-W21',
+      html_url: 'https://github.com/baladithyab/UCSC-CSE-160-W21',
+      description: 'WebGL graphics assignments',
+      stars: 3,
+    }
+    const result = annotateWithEmbedSlug(repo, slugMap)
+    expect(result).toMatchObject({
+      name: 'UCSC-CSE-160-W21',
+      description: 'WebGL graphics assignments',
+      stars: 3,
+      embedSlug: 'cse-160-asg2',
+    })
+  })
+
+  it('case-insensitive match against the html_url', () => {
+    const repo: RepoLike = {
+      name: 'UCSC-CSE-160-W21',
+      html_url: 'https://github.com/BalaDithyaB/UCSC-CSE-160-W21',
+    }
+    const result = annotateWithEmbedSlug(repo, slugMap)
+    expect((result as RepoLike & { embedSlug?: string }).embedSlug).toBe('cse-160-asg2')
+  })
+})

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure helpers for joining GitHub repo lists with the embedded-project
+ * content collection.
+ *
+ * Kept separate from `src/lib/github.ts` and `astro:content` so vitest can
+ * exercise the join logic without needing to resolve Astro's virtual
+ * modules. The thin glue that calls `getCollection('projects')` lives in
+ * `src/pages/profile.astro` itself.
+ */
+
+/** Minimal shape of a project content entry needed for the join. */
+export interface ProjectEntryLike {
+  data: {
+    slug: string
+    discovery: {
+      /** GitHub `<owner>/<name>` of the source repo. */
+      source: string
+    }
+  }
+}
+
+/** Minimal shape of a GitHub repo needed for the join. */
+export interface RepoLike {
+  /** Bare repo name (no owner). */
+  name: string
+  /** Canonical GitHub URL — used to recover the owner. */
+  html_url: string
+}
+
+/**
+ * Build a map from `<owner>/<name>` (lowercased) to project slug.
+ *
+ * GitHub URLs are normalised by stripping a trailing slash and `.git`
+ * suffix, then lowercasing — `Source` field comparisons stay
+ * case-insensitive so a manifest pointing at `BalaDithyaB/UCSC-CSE-160-W21`
+ * still joins against the API's `baladithyab/UCSC-CSE-160-W21` URL. The
+ * map is the join key; callers do `map.get(repoFullName(repo))`.
+ *
+ * If two manifests claim the same source repo (shouldn't happen in
+ * practice — slug collisions are rejected upstream by
+ * `sync-project-manifests.ts`), first one wins. We log to console at
+ * call-time, not here, so this stays a pure function.
+ */
+export function buildEmbedSlugMap(entries: ProjectEntryLike[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const entry of entries) {
+    const key = entry.data.discovery.source.toLowerCase()
+    if (!map.has(key)) map.set(key, entry.data.slug)
+  }
+  return map
+}
+
+/**
+ * Recover `<owner>/<name>` from a GitHub html_url. Returns lowercase to
+ * match the map keys built by `buildEmbedSlugMap`.
+ *
+ * Examples:
+ * - `https://github.com/baladithyab/UCSC-CSE-160-W21` → `baladithyab/ucsc-cse-160-w21`
+ * - `https://github.com/baladithyab/UCSC-CSE-160-W21/` → same
+ * - `https://github.com/Baladithyab/UCSC-CSE-160-W21.git` → same
+ * - `https://github.com/baladithyab` (no /repo) → `null`
+ */
+export function repoFullNameFromUrl(htmlUrl: string): string | null {
+  let url: URL
+  try {
+    url = new URL(htmlUrl)
+  } catch {
+    return null
+  }
+  if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') return null
+  // Strip leading slash, trailing slash, optional `.git`.
+  const path = url.pathname.replace(/^\/+/, '').replace(/\/+$/, '').replace(/\.git$/i, '')
+  const parts = path.split('/')
+  if (parts.length < 2) return null
+  return `${parts[0]}/${parts[1]}`.toLowerCase()
+}
+
+/**
+ * Augment a list of repos with `embedSlug` where one matches the project
+ * entry collection. Pure function — same inputs always yield same outputs.
+ *
+ * Callers stay simple:
+ *
+ * ```ts
+ * const projects = await getCollection('projects')
+ * const repos = (summary?.topRepos ?? []).map(r => annotateWithEmbedSlug(r, buildEmbedSlugMap(projects)))
+ * ```
+ */
+export function annotateWithEmbedSlug<R extends RepoLike & { embedSlug?: string }>(
+  repo: R,
+  slugMap: Map<string, string>,
+): R {
+  const fullName = repoFullNameFromUrl(repo.html_url)
+  if (!fullName) return repo
+  const slug = slugMap.get(fullName)
+  if (!slug) return repo
+  return { ...repo, embedSlug: slug }
+}

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -5,16 +5,18 @@ import { Avatar } from '@/components/ui/avatar'
 import GrommetIconsGithub from '~icons/grommet-icons/github'
 import GrommetIconsLinkedin from '~icons/grommet-icons/linkedin'
 import GrommetIconsMail from '~icons/grommet-icons/mail'
-import type { GitHubEnv } from '@/lib/github'
+import type { GitHubEnv, Repo } from '@/lib/github'
 import { getGitHubSummary } from '@/lib/github'
 import { getRuntimeEnv } from '@/lib/runtime-env'
+import { annotateWithEmbedSlug, buildEmbedSlugMap } from '@/lib/projects'
+import { getCollection } from 'astro:content'
 import RepoGrid from '@/components/RepoGrid'
 import GithubSummary from '@/components/GithubSummary.astro'
 
 // Get runtime environment from Cloudflare Workers (for optional GitHub token + caching)
 const runtimeEnv = getRuntimeEnv<GitHubEnv>()
 
-let repos: any[] = []
+let repos: Repo[] = []
 let summary: any | null = null
 let repoError: string | null = null
 try {
@@ -23,6 +25,19 @@ try {
 } catch (error) {
   console.error('Error fetching repos:', error)
   repoError = error instanceof Error ? error.message : 'Unknown error'
+}
+
+// Join GitHub repos against the projects content collection so any repo that
+// has a `web.codeseys.json` manifest links to its in-site /projects/<slug>
+// page (the playable demo) instead of GitHub.
+try {
+  const projectEntries = await getCollection('projects')
+  const slugMap = buildEmbedSlugMap(projectEntries)
+  repos = repos.map((r) => annotateWithEmbedSlug(r, slugMap))
+} catch (error) {
+  // Don't fail the page if the projects collection is unavailable —
+  // RepoGrid falls back to the original GitHub link by default.
+  console.error('Error annotating repos with embed slugs:', error)
 }
 ---
 


### PR DESCRIPTION
## Summary

Reported by user: clicking the UCSC-CSE-160-W21 repo card on `/profile` was opening GitHub instead of the in-site `/projects/cse-160-asg2` page (which is the playable WebGL Charmeleon demo).

This PR makes any repo that backs an embeddable project link to its in-site demo page instead of GitHub. Repos without a manifest keep the current external-link behavior — no regression for the other 29 repos on the profile.

## Behavior

| Repo state | Card shows | Link goes to |
|---|---|---|
| Has a `web.codeseys.json` discovered into the projects collection | `Play` icon + `LIVE DEMO` pill badge | `/projects/<slug>` (same tab) |
| No manifest | `ExternalLink` icon | `https://github.com/<owner>/<repo>` (new tab) |

## How the join works

Pure-helper module `src/lib/projects.ts`:

1. `repoFullNameFromUrl(htmlUrl)` parses `<owner>/<name>` out of a GitHub URL (handles trailing slash, `.git`, mixed case, extra segments, www subdomain).
2. `buildEmbedSlugMap(projectEntries)` aggregates the projects content collection into a `Map<sourceRepoFullName, slug>` keyed lowercase.
3. `annotateWithEmbedSlug(repo, slugMap)` adds `embedSlug` to a repo when matched, returns it unchanged otherwise.

`profile.astro` fetches `getCollection('projects')` after the GitHub API call, builds the map, and runs each repo through `annotateWithEmbedSlug`. `RepoGrid.tsx` branches on `repo.embedSlug` for the link/icon/badge.

## Why a separate module instead of inlining in profile.astro

Pure helpers stay testable in vitest without Astro's virtual `astro:content` module. The thin glue (`getCollection` + map) lives in `profile.astro` itself. 18 tests cover the helpers — round-trip URL parsing, dedupe, case-insensitivity, missing-data fallback, field preservation.

## Verification

- `bun run test` → **120/120** (was 102, +18 in `projects.test.ts`)
- `bun run astro check` → 0/0/0
- `bun run build` clean
- Local preview confirmed via DOM inspection:
  - UCSC-CSE-160-W21 card → `href="/projects/cse-160-asg2"`, no `target=_blank`, `Play` icon present, `Live demo` text present
  - Click navigates same-tab; WebGL embed renders with 0 console errors
  - Other repos (e.g. `web-embed-workflows`, `hermes-quant`) unchanged
