### PR TITLE
style(blog): theme mermaid diagrams to site palette (light + dark)

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -33,6 +33,12 @@ const mermaidConfig: [typeof rehypeMermaid, Parameters<typeof rehypeMermaid>[0]]
       themeVariables: {
         // Use a fontFamily that matches our site so labels look native.
         fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+        // Bump from mermaid's default 16px to 17px — small change that
+        // makes dense flowcharts noticeably more readable without
+        // forcing diagrams to overflow the prose column. The theme CSS
+        // (in [slug].astro) repaints node fills + edge label backplates
+        // to match the site palette in both light and dark modes.
+        fontSize: '17px',
       },
     },
   },

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -362,9 +362,22 @@ const otherPosts = sortBlogPosts(
     color: hsl(var(--foreground)) !important;
     fill: hsl(var(--foreground)) !important;
   }
+  /* Mermaid v11 emits edge labels as `<foreignObject>` containing a
+     `<div class="labelBkg">` with a hardcoded white background-color,
+     plus `<span class="edgeLabel">` with its own bg. The bare `rect`
+     selector misses both. Cover all known emit shapes:
+       - `.edgeLabel rect` (older / non-foreignObject path)
+       - `.edgeLabel .label-container`
+       - `.edgeLabel .labelBkg` (foreignObject div backplate)
+       - `.edgeLabel span.edgeLabel` (the inner span carries its own bg)
+     We force the backplate to the page bg so floating labels read as
+     "text on page" rather than "white card on dark page". */
   .dark .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel rect,
-  .dark .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel .label-container {
+  .dark .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel .label-container,
+  .dark .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel .labelBkg,
+  .dark .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel span.edgeLabel {
     fill: hsl(var(--background)) !important;
+    background-color: hsl(var(--background)) !important;
   }
 
   /* Flowchart EDGES (the connecting arrows). The neutral theme renders
@@ -373,6 +386,117 @@ const otherPosts = sortBlogPosts(
   .dark .prose .mermaid-frame svg[id^='mermaid-'] path.flowchart-link {
     stroke: hsl(var(--muted-foreground)) !important;
     fill: none !important;
+  }
+  /* Edge arrowheads use a path inside [id$='-pointEnd'] / [id$='-pointStart']
+     markers in v11. Without this they stay dark gray on a dark bg. */
+  .dark .prose .mermaid-frame svg[id^='mermaid-'] [id$='-pointEnd'] path,
+  .dark .prose .mermaid-frame svg[id^='mermaid-'] [id$='-pointStart'] path,
+  .dark .prose .mermaid-frame svg[id^='mermaid-'] [id$='-circleEnd'] circle,
+  .dark .prose .mermaid-frame svg[id^='mermaid-'] [id$='-circleStart'] circle {
+    stroke: hsl(var(--muted-foreground)) !important;
+    fill: hsl(var(--muted-foreground)) !important;
+  }
+
+  /* ─────────────────────────────────────────────────────────────────────
+     LIGHT MODE: mermaid's neutral theme renders washed-out on a white
+     page (#ECECFF node fills, thin gray strokes, low-contrast labels).
+     Tint diagrams to use the site palette so they feel native and stay
+     readable. Same selector shape as the .dark block above, minus the
+     leading `.dark` so these apply by default.
+     ───────────────────────────────────────────────────────────────────── */
+
+  /* Flowchart node boxes — inherit card surface + site border. */
+  .prose .mermaid-frame svg[id^='mermaid-'] g.node > rect,
+  .prose .mermaid-frame svg[id^='mermaid-'] g.node > polygon,
+  .prose .mermaid-frame svg[id^='mermaid-'] g.node > circle,
+  .prose .mermaid-frame svg[id^='mermaid-'] g.node > path,
+  .prose .mermaid-frame svg[id^='mermaid-'] g.node rect.basic.label-container {
+    fill: hsl(var(--card)) !important;
+    stroke: hsl(var(--border)) !important;
+    stroke-width: 1.25px !important;
+  }
+
+  /* Node labels — explicit foreground so neither prose color nor mermaid's
+     #333 default wins. Covers tspan, foreignObject p, and the .nodeLabel span. */
+  .prose .mermaid-frame svg[id^='mermaid-'] .nodeLabel,
+  .prose .mermaid-frame svg[id^='mermaid-'] .nodeLabel > p,
+  .prose .mermaid-frame svg[id^='mermaid-'] foreignObject .nodeLabel,
+  .prose .mermaid-frame svg[id^='mermaid-'] foreignObject p,
+  .prose .mermaid-frame svg[id^='mermaid-'] text.nodeLabel,
+  .prose .mermaid-frame svg[id^='mermaid-'] text.nodeLabel > tspan {
+    color: hsl(var(--foreground)) !important;
+    fill: hsl(var(--foreground)) !important;
+  }
+
+  /* Edges — primary tint reads as "site link color" so connections feel
+     intentional, and stays visible on white without going harsh-black. */
+  .prose .mermaid-frame svg[id^='mermaid-'] .flowchart-link,
+  .prose .mermaid-frame svg[id^='mermaid-'] path.flowchart-link {
+    stroke: hsl(var(--muted-foreground)) !important;
+    stroke-width: 1.5px !important;
+    fill: none !important;
+  }
+  .prose .mermaid-frame svg[id^='mermaid-'] [id$='-pointEnd'] path,
+  .prose .mermaid-frame svg[id^='mermaid-'] [id$='-pointStart'] path,
+  .prose .mermaid-frame svg[id^='mermaid-'] [id$='-circleEnd'] circle,
+  .prose .mermaid-frame svg[id^='mermaid-'] [id$='-circleStart'] circle {
+    stroke: hsl(var(--muted-foreground)) !important;
+    fill: hsl(var(--muted-foreground)) !important;
+  }
+
+  /* Edge labels — match page bg so the text "floats" instead of sitting
+     on a white card. Targets all v11 emit shapes (rect, label-container,
+     labelBkg div, inner span). */
+  .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel,
+  .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel > p,
+  .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel foreignObject,
+  .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel foreignObject p {
+    color: hsl(var(--foreground)) !important;
+    fill: hsl(var(--foreground)) !important;
+  }
+  .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel rect,
+  .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel .label-container,
+  .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel .labelBkg,
+  .prose .mermaid-frame svg[id^='mermaid-'] .edgeLabel span.edgeLabel {
+    fill: hsl(var(--background)) !important;
+    background-color: hsl(var(--background)) !important;
+  }
+
+  /* Sequence diagrams (light mode): neutral theme already uses #eee actor
+     boxes with #333 labels which is fine on white. We only normalize the
+     actor stroke + arrows to use the site palette so it doesn't clash. */
+  .prose .mermaid-frame svg[id^='mermaid-'] rect.actor,
+  .prose .mermaid-frame svg[id^='mermaid-'] rect.actor.outer-path,
+  .prose .mermaid-frame svg[id^='mermaid-'] .labelBox {
+    fill: hsl(var(--card)) !important;
+    stroke: hsl(var(--border)) !important;
+  }
+  .prose .mermaid-frame svg[id^='mermaid-'] .actor-line {
+    stroke: hsl(var(--muted-foreground) / 0.5) !important;
+  }
+  .prose .mermaid-frame svg[id^='mermaid-'] .messageLine0,
+  .prose .mermaid-frame svg[id^='mermaid-'] .messageLine1 {
+    stroke: hsl(var(--muted-foreground)) !important;
+    fill: none !important;
+  }
+  .prose .mermaid-frame svg[id^='mermaid-'] [id$='-arrowhead'] path,
+  .prose .mermaid-frame svg[id^='mermaid-'] [id$='-crosshead'] path,
+  .prose .mermaid-frame svg[id^='mermaid-'] .marker,
+  .prose .mermaid-frame svg[id^='mermaid-'] .marker.cross {
+    stroke: hsl(var(--muted-foreground)) !important;
+    fill: hsl(var(--muted-foreground)) !important;
+  }
+  .prose .mermaid-frame svg[id^='mermaid-'] text.actor,
+  .prose .mermaid-frame svg[id^='mermaid-'] text.actor > tspan,
+  .prose .mermaid-frame svg[id^='mermaid-'] text.actor-box,
+  .prose .mermaid-frame svg[id^='mermaid-'] text.actor-box > tspan,
+  .prose .mermaid-frame svg[id^='mermaid-'] .messageText,
+  .prose .mermaid-frame svg[id^='mermaid-'] .messageText > tspan,
+  .prose .mermaid-frame svg[id^='mermaid-'] .labelText,
+  .prose .mermaid-frame svg[id^='mermaid-'] .labelText > tspan,
+  .prose .mermaid-frame svg[id^='mermaid-'] .loopText,
+  .prose .mermaid-frame svg[id^='mermaid-'] .loopText > tspan {
+    fill: hsl(var(--foreground)) !important;
   }
   /* Subtle right-edge fade as a visual cue that the diagram is scrollable.
      Sticky positioning so it stays at the right edge regardless of scroll. */


### PR DESCRIPTION
## Why

Screenshots from the embeds-architecture post showed two issues:
- **Dark mode:** edge-label rects rendered as solid white blocks (`if bundle: fetch + stage to dist/`, etc.) — existing CSS missed mermaid v11's foreignObject `labelBkg` div + inner `span.edgeLabel`.
- **Light mode:** no overrides at all. Neutral theme's `#ECECFF` node fills + thin gray strokes washed out on a white page.

## What

CSS-only fix in `src/pages/blog/[slug].astro`:
- Harden dark-mode edge-label backplate (cover `.labelBkg`, `span.edgeLabel`; both `fill` + `background-color`).
- Add dark-mode arrowhead rules (`[id$='-pointEnd']` v11 markers).
- Add a full light-mode block mirroring dark selectors — nodes use `--card` + `--border`, edges use `--muted-foreground`, edge labels use `--background` backplate, sequence diagrams normalized to site palette.

Plus `themeVariables.fontSize: 16 → 17px` in `astro.config.ts` for denser diagrams.

## Verified
- `bun run build` green (Playwright + rehype-mermaid prerender unchanged)
- Content-agnostic — future mermaid blocks inherit the look without per-post `classDef`s.