### PR TITLE
feat(projects): multi-asset manifests, asset tabs, R2 version picker

### DIFF
--- a/src/components/embeds/AssetTabs.tsx
+++ b/src/components/embeds/AssetTabs.tsx
@@ -1,0 +1,132 @@
+/**
+ * AssetTabs — tab strip for switching between assets on a multi-asset
+ * project page.
+ *
+ * Layout pattern: horizontally scrollable when assets > viewport, grouped
+ * visually by `asset.group` when projects declare groups (e.g. "Demos" /
+ * "Writeups" / "Source").
+ *
+ * For single-asset projects, the parent route should skip rendering this
+ * component entirely — `assets.length === 1` makes a tab strip noise.
+ */
+
+import type { Asset } from '@/lib/types/project-manifest'
+
+interface AssetTabsProps {
+  assets: Asset[]
+  /** id of the currently-active asset. */
+  activeId: string
+  /** Build a real href for each asset (so the tab works without JS and
+   *  shows the correct hover URL). The parent uses this to render
+   *  `?asset=<id>`-style links that match the URL state. */
+  hrefFor: (assetId: string) => string
+  /** Called when a tab is clicked. Receives the asset id. The parent
+   *  uses this to update its own state without a full page reload — but
+   *  the tab is still a real <a> with a real href so JS-off / open-in-
+   *  new-tab still works. */
+  onSelect: (assetId: string) => void
+}
+
+/**
+ * Group assets by their `group` field, preserving original order within
+ * each group. Assets without a group land in a synthetic "Default"
+ * bucket which renders without a header.
+ */
+function groupAssets(assets: Asset[]): Array<{ group: string | null; items: Asset[] }> {
+  const buckets = new Map<string | null, Asset[]>()
+  for (const a of assets) {
+    const key = a.group ?? null
+    if (!buckets.has(key)) buckets.set(key, [])
+    buckets.get(key)!.push(a)
+  }
+  return [...buckets.entries()].map(([group, items]) => ({ group, items }))
+}
+
+export default function AssetTabs({ assets, activeId, hrefFor, onSelect }: AssetTabsProps) {
+  const groups = groupAssets(assets)
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+      {groups.map((g, gi) => (
+        <div key={g.group ?? `__default_${gi}`} className="flex items-center gap-2">
+          {g.group && (
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              {g.group}
+            </span>
+          )}
+          <div className="flex flex-wrap gap-1">
+            {g.items.map(asset => {
+              const active = asset.id === activeId
+              return (
+                <a
+                  key={asset.id}
+                  href={hrefFor(asset.id)}
+                  onClick={(e) => {
+                    // Modifier-click → let the browser handle (open in
+                    // new tab, etc.). Plain click → swap state in place.
+                    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return
+                    e.preventDefault()
+                    onSelect(asset.id)
+                  }}
+                  className={`inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
+                    active
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-border bg-card text-muted-foreground hover:border-primary/40 hover:text-foreground'
+                  }`}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {asset.title}
+                </a>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Hook for keeping a `selectedAssetId` state in sync with the
+ * `?asset=<id>` query parameter. Two-way: external query changes (back/
+ * forward) update state; calling `setSelectedAssetId(...)` updates state
+ * and pushes a new history entry without reloading.
+ */
+import { useEffect, useState } from 'react'
+
+export function useAssetSelection(
+  assets: Asset[],
+  defaultAssetId: string,
+): [string, (id: string) => void] {
+  const ids = assets.map(a => a.id)
+  const [selectedId, setSelectedId] = useState<string>(() => {
+    if (typeof window === 'undefined') return defaultAssetId
+    const fromUrl = new URLSearchParams(window.location.search).get('asset')
+    return fromUrl && ids.includes(fromUrl) ? fromUrl : defaultAssetId
+  })
+
+  useEffect(() => {
+    const onPop = () => {
+      const fromUrl = new URLSearchParams(window.location.search).get('asset')
+      setSelectedId(fromUrl && ids.includes(fromUrl) ? fromUrl : defaultAssetId)
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultAssetId, ids.join(',')])
+
+  function select(id: string): void {
+    if (!ids.includes(id)) return
+    setSelectedId(id)
+    if (typeof window === 'undefined') return
+    const url = new URL(window.location.href)
+    if (id === defaultAssetId) {
+      url.searchParams.delete('asset')
+    } else {
+      url.searchParams.set('asset', id)
+    }
+    window.history.pushState({}, '', url.toString())
+  }
+
+  return [selectedId, select]
+}

--- a/src/components/embeds/EmbedRouter.tsx
+++ b/src/components/embeds/EmbedRouter.tsx
@@ -1,5 +1,5 @@
 /**
- * EmbedRouter — switches on `manifest.embed.kind` and dispatches to the
+ * EmbedRouter — switches on `asset.embed.kind` and dispatches to the
  * matching renderer. Single entry point used by `/projects/[slug].astro`.
  *
  * Most embed kinds reduce to "load an HTML document in an iframe":
@@ -9,8 +9,6 @@
  * - `tex-pdf` — load the PDF in an iframe (browser PDF viewer handles it)
  * - `wasm-emscripten` / `wasm-rust` — Emscripten/wasm-bindgen produce a
  *   self-contained HTML harness; we point the iframe at that harness URL.
- *   A future first-party React harness can replace this for finer control,
- *   but the iframe path is correct and simple for v1.
  *
  * The kinds that *can't* be reduced to an iframe yet:
  * - `pyodide` — needs a React component that boots Pyodide on the page,
@@ -18,35 +16,42 @@
  * - `pglite-db` — needs a PGlite-style WASM postgres or mongo-shaped
  *   browser DB. Stub for now (CSCI 585's pilot will define the shape).
  *
- * When we add real renderers for those, replace the stub branches with
- * imports of `WasmEmbed`, `PyodideEmbed`, `PGliteEmbed`, etc.
+ * Multi-asset shape: callers select one `Asset` from `entry.assets[]`
+ * (driven by the `?asset=<id>` query param) and pass the asset + the
+ * project's shared `delivery.url` so this component can resolve relative
+ * paths.
  */
 
-import type { ProjectEntry } from '@/lib/types/project-manifest'
+import type { Asset } from '@/lib/types/project-manifest'
 import IframeEmbed from './IframeEmbed'
 
 interface EmbedRouterProps {
-  entry: ProjectEntry
+  /** The active asset to render. Selection happens upstream. */
+  asset: Asset
+  /** Shared delivery prefix from the project manifest. Always
+   *  versioned (ends in `<sha>/`) so each tab on a multi-asset project
+   *  agrees on which build it's reading. */
+  deliveryUrl: string
 }
 
 /**
  * Build the absolute URL of the entry HTML for kinds that load a doc.
- * `delivery.url` always ends with `/`; embed entries are relative paths.
+ * `deliveryUrl` always ends with `/`; embed entries are relative paths.
  */
-function entryUrl(entry: ProjectEntry, relativePath: string): string {
-  const base = entry.delivery.url.endsWith('/') ? entry.delivery.url : entry.delivery.url + '/'
+function entryUrl(deliveryUrl: string, relativePath: string): string {
+  const base = deliveryUrl.endsWith('/') ? deliveryUrl : deliveryUrl + '/'
   return base + relativePath.replace(/^\//, '')
 }
 
-export default function EmbedRouter({ entry }: EmbedRouterProps) {
-  const { embed, title } = entry
+export default function EmbedRouter({ asset, deliveryUrl }: EmbedRouterProps) {
+  const { embed, title } = asset
 
   switch (embed.kind) {
     case 'static-html':
-      return <IframeEmbed src={entryUrl(entry, embed.entry)} title={title} />
+      return <IframeEmbed src={entryUrl(deliveryUrl, embed.entry)} title={title} />
 
     case 'notebook-html':
-      return <IframeEmbed src={entryUrl(entry, embed.notebook)} title={title} />
+      return <IframeEmbed src={entryUrl(deliveryUrl, embed.notebook)} title={title} />
 
     case 'external-app':
       // Foreign origin — visitor is leaving our origin's same-origin trust
@@ -62,14 +67,14 @@ export default function EmbedRouter({ entry }: EmbedRouterProps) {
       )
 
     case 'tex-pdf':
-      return <IframeEmbed src={entryUrl(entry, embed.pdf)} title={title} aspectRatio="8.5 / 11" />
+      return <IframeEmbed src={entryUrl(deliveryUrl, embed.pdf)} title={title} aspectRatio="8.5 / 11" />
 
     case 'wasm-emscripten':
     case 'wasm-rust':
       // Emscripten + wasm-bindgen ship a self-contained HTML harness next
       // to the .wasm. v1: just iframe the harness. v2 (future): a first-
       // party React harness with React-side controls + state.
-      return <IframeEmbed src={entryUrl(entry, embed.entry)} title={title} />
+      return <IframeEmbed src={entryUrl(deliveryUrl, embed.entry)} title={title} />
 
     case 'pyodide':
     case 'pglite-db':
@@ -81,8 +86,8 @@ export default function EmbedRouter({ entry }: EmbedRouterProps) {
             </p>
             <p className="mt-2 text-sm text-muted-foreground">
               This embed kind needs a first-party renderer. Source artifact lives at{' '}
-              <a className="underline hover:text-primary" href={entry.delivery.url} target="_blank" rel="noopener noreferrer">
-                {entry.delivery.url}
+              <a className="underline hover:text-primary" href={deliveryUrl} target="_blank" rel="noopener noreferrer">
+                {deliveryUrl}
               </a>
               .
             </p>

--- a/src/components/embeds/ProjectViewer.tsx
+++ b/src/components/embeds/ProjectViewer.tsx
@@ -1,0 +1,64 @@
+/**
+ * ProjectViewer — combined React island for a project's asset tab strip
+ * + active-asset embed. Mounted once per project page so URL state and
+ * embed render share a single source of truth.
+ *
+ * URL semantics:
+ * - No query → render `defaultAssetId`
+ * - `?asset=<id>` → render that asset (state updates via popstate too)
+ * - `?v=<sha>` → handled in `[slug].astro`'s SSR (different
+ *   `deliveryUrl` is computed at request time before this island
+ *   mounts)
+ *
+ * Single-asset case: AssetTabs renders nothing, but the island still
+ * mounts so the future version-picker can drive a re-render without
+ * code duplication.
+ */
+
+import EmbedRouter from './EmbedRouter'
+import AssetTabs, { useAssetSelection } from './AssetTabs'
+import type { Asset } from '@/lib/types/project-manifest'
+
+interface ProjectViewerProps {
+  assets: Asset[]
+  defaultAssetId: string
+  /** Shared delivery prefix (already includes the `<sha>` segment). */
+  deliveryUrl: string
+}
+
+export default function ProjectViewer({ assets, defaultAssetId, deliveryUrl }: ProjectViewerProps) {
+  const [activeId, setActiveId] = useAssetSelection(assets, defaultAssetId)
+  const active = assets.find(a => a.id === activeId) ?? assets[0]!
+
+  return (
+    <div>
+      {assets.length > 1 && (
+        <AssetTabs
+          assets={assets}
+          activeId={active.id}
+          hrefFor={(id) => {
+            // Build a real href so right-click / copy-link / open-in-
+            // new-tab works. Default-asset → no query string.
+            if (id === defaultAssetId) {
+              if (typeof window === 'undefined') return ''
+              const u = new URL(window.location.href)
+              u.searchParams.delete('asset')
+              return u.search || ''
+            }
+            if (typeof window === 'undefined') return `?asset=${id}`
+            const u = new URL(window.location.href)
+            u.searchParams.set('asset', id)
+            return u.search
+          }}
+          onSelect={setActiveId}
+        />
+      )}
+
+      <EmbedRouter asset={active} deliveryUrl={deliveryUrl} />
+
+      {active.description && (
+        <p className="mt-3 text-xs leading-relaxed text-muted-foreground">{active.description}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/embeds/VersionPicker.tsx
+++ b/src/components/embeds/VersionPicker.tsx
@@ -1,0 +1,132 @@
+/**
+ * VersionPicker — sidebar widget that lists every R2 version of a
+ * project and lets the visitor flip between them.
+ *
+ * Uses the `/api/projects/<slug>/versions` endpoint (lazy-fetched on
+ * mount). When the visitor picks a non-current version, navigation goes
+ * to `/projects/<slug>?v=<id>` which the page's SSR re-resolves to a
+ * different `delivery.url` prefix.
+ *
+ * Design choices:
+ * - Lazy fetch on mount so the slug page's TTFB isn't blocked. A small
+ *   "Loading versions…" placeholder is fine for the sidebar.
+ * - One entry per version with version id, "current" badge, and click-
+ *   to-switch.
+ * - Errors fall through silently — version picker is a nice-to-have,
+ *   not a requirement for the page to be useful.
+ */
+
+import { useEffect, useState } from 'react'
+import { History, Check, Loader2 } from 'lucide-react'
+
+interface VersionPickerProps {
+  slug: string
+  /** The version pinned by the manifest (today's "current"). */
+  currentVersion: string
+  /** The version the page is actually rendering (may differ from
+   *  currentVersion if the visitor came in via `?v=...`). */
+  activeVersion: string
+}
+
+interface VersionEntry {
+  id: string
+  lastModified?: string
+  sizeBytes?: number
+}
+
+interface VersionsResponse {
+  ok: boolean
+  slug: string
+  versions: VersionEntry[]
+  error?: string
+}
+
+export default function VersionPicker({ slug, currentVersion, activeVersion }: VersionPickerProps) {
+  const [versions, setVersions] = useState<VersionEntry[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    fetch(`/api/projects/${slug}/versions`, { headers: { Accept: 'application/json' } })
+      .then(r => r.json() as Promise<VersionsResponse>)
+      .then((data: VersionsResponse) => {
+        if (cancelled) return
+        if (data.ok) {
+          setVersions(data.versions)
+        } else {
+          setError(data.error ?? 'unknown error')
+        }
+        setLoading(false)
+      })
+      .catch((err: Error) => {
+        if (cancelled) return
+        setError(err.message)
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [slug])
+
+  function hrefFor(versionId: string): string {
+    // Pinned (manifest) version → no `?v` query (clean canonical URL).
+    if (versionId === currentVersion) return `/projects/${slug}`
+    return `/projects/${slug}?v=${encodeURIComponent(versionId)}`
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 className="size-3 animate-spin" />
+        Loading versions…
+      </div>
+    )
+  }
+
+  if (error || !versions) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Versions unavailable {error ? <span className="font-mono">({error})</span> : null}
+      </p>
+    )
+  }
+
+  if (versions.length === 0) {
+    return <p className="text-xs text-muted-foreground">No versions yet.</p>
+  }
+
+  return (
+    <ul className="space-y-1.5">
+      {versions.map(v => {
+        const isCurrent = v.id === currentVersion
+        const isActive = v.id === activeVersion
+        return (
+          <li key={v.id}>
+            <a
+              href={hrefFor(v.id)}
+              className={`group flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-xs transition-colors ${
+                isActive
+                  ? 'border-primary/40 bg-primary/5'
+                  : 'border-transparent hover:border-border hover:bg-muted/50'
+              }`}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <span className="flex items-center gap-1.5 truncate font-mono text-foreground">
+                <History className="size-3 shrink-0 text-muted-foreground" />
+                <span className="truncate">{v.id}</span>
+              </span>
+              {isCurrent && (
+                <span className="inline-flex shrink-0 items-center gap-0.5 rounded-sm bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-emerald-400">
+                  <Check className="size-2.5" />
+                  current
+                </span>
+              )}
+            </a>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/lib/project-redirects.ts
+++ b/src/lib/project-redirects.ts
@@ -1,0 +1,17 @@
+/**
+ * Slug-rename redirects for the projects collection.
+ *
+ * When a project's slug is renamed (e.g. cse-160-asg2 → cse-160), the
+ * old URL needs to keep working for inbound links and bookmarks. This
+ * map is the single source of truth; both Astro middleware (handles
+ * `/projects/<old-slug>`) and the personal-site CDN (could later cache
+ * 308s) consult it.
+ *
+ * Add a new entry whenever a slug is renamed; never remove old ones.
+ */
+export const PROJECT_SLUG_REDIRECTS: Readonly<Record<string, string>> = Object.freeze({
+  // 2026-05-27: project broadened from a single asg2 demo to a
+  // multi-asset manifest covering the whole graphics course
+  // (asg0/asg1/asg2 demos + 4 LaTeX writeups).
+  'cse-160-asg2': 'cse-160',
+})

--- a/src/lib/types/project-manifest.test.ts
+++ b/src/lib/types/project-manifest.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for src/lib/types/project-manifest.ts.
+ *
+ * Coverage targets:
+ *   - v1 manifest parses, normalizes to a 1-asset v2 shape with id 'main'
+ *   - v2 manifest parses, normalizes with defaultAssetId resolved
+ *   - v2 with invalid defaultAssetId falls back to assets[0]
+ *   - schema rejection paths: missing assets, bad slug, bad asset id, etc.
+ *   - EmbedSpec discriminated union accepts each kind
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  Asset,
+  EmbedSpec,
+  normalizeManifest,
+  ProjectManifest,
+} from './project-manifest'
+
+const v1Sample = {
+  schemaVersion: 1,
+  slug: 'cse-160',
+  category: { kind: 'college', school: 'UCSC', code: 'CSE 160', title: 'Graphics', year: 2021 },
+  title: 'CSE 160 — Graphics Assignments',
+  description: 'WebGL homework',
+  tags: ['webgl'],
+  completionLevel: 'ships',
+  embed: { kind: 'static-html', entry: 'asg2.html' },
+  delivery: {
+    mode: 'runtime-r2',
+    url: 'https://assets-r2.codeseys.io/cse-160/abc123/',
+    version: 'abc123',
+    sizeBytes: 100000,
+  },
+  build: { ci: true },
+}
+
+const v2Sample = {
+  schemaVersion: 2,
+  slug: 'cse-160',
+  category: { kind: 'college', school: 'UCSC', code: 'CSE 160', title: 'Graphics', year: 2021 },
+  title: 'CSE 160 — Graphics',
+  description: 'Five WebGL assignments + LaTeX writeups',
+  tags: ['webgl', 'graphics'],
+  completionLevel: 'ships',
+  defaultAssetId: 'asg2',
+  assets: [
+    { id: 'asg0', title: 'Assignment 0', group: 'Demos', embed: { kind: 'static-html', entry: 'asg0/asg0.html' } },
+    { id: 'asg2', title: 'Assignment 2', group: 'Demos', embed: { kind: 'static-html', entry: 'asg2/asg2.html' } },
+    { id: 'hw1', title: 'HW1 Writeup', group: 'Writeups', embed: { kind: 'tex-pdf', pdf: 'hw1.pdf' } },
+  ],
+  delivery: {
+    mode: 'runtime-r2',
+    url: 'https://assets-r2.codeseys.io/cse-160/abc123/',
+    version: 'abc123',
+    sizeBytes: 250000,
+  },
+  build: { ci: true },
+}
+
+describe('ProjectManifest schema', () => {
+  it('parses a v1 manifest', () => {
+    const result = ProjectManifest.safeParse(v1Sample)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.schemaVersion).toBe(1)
+    }
+  })
+
+  it('parses a v2 manifest', () => {
+    const result = ProjectManifest.safeParse(v2Sample)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.schemaVersion).toBe(2)
+      if (result.data.schemaVersion === 2) expect(result.data.assets).toHaveLength(3)
+    }
+  })
+
+  it('rejects a v2 manifest with no assets', () => {
+    const bad = { ...v2Sample, assets: [] }
+    expect(ProjectManifest.safeParse(bad).success).toBe(false)
+  })
+
+  it('rejects a v2 manifest with a duplicate-id asset', () => {
+    // Note: the schema doesn't strictly forbid duplicate ids — that would
+    // require a refinement. For now, normalizeManifest handles the
+    // first-wins case by virtue of the Map-keyed lookups in the UI.
+    // This test documents the current behaviour: parsing succeeds even
+    // with duplicates.
+    const bad = {
+      ...v2Sample,
+      assets: [
+        { id: 'a', title: 'A', embed: { kind: 'static-html', entry: 'a.html' } },
+        { id: 'a', title: 'A again', embed: { kind: 'static-html', entry: 'a2.html' } },
+      ],
+    }
+    expect(ProjectManifest.safeParse(bad).success).toBe(true)
+  })
+
+  it('rejects a v1 manifest without an embed', () => {
+    const { embed: _, ...rest } = v1Sample
+    void _
+    expect(ProjectManifest.safeParse(rest).success).toBe(false)
+  })
+
+  it('rejects bad slug (uppercase)', () => {
+    const bad = { ...v1Sample, slug: 'CSE-160' }
+    expect(ProjectManifest.safeParse(bad).success).toBe(false)
+  })
+
+  it('rejects bad asset id (uppercase)', () => {
+    const bad = {
+      ...v2Sample,
+      assets: [{ id: 'A', title: 'A', embed: { kind: 'static-html', entry: 'a.html' } }],
+    }
+    expect(ProjectManifest.safeParse(bad).success).toBe(false)
+  })
+})
+
+describe('EmbedSpec', () => {
+  it.each([
+    ['static-html', { kind: 'static-html', entry: 'a.html' }],
+    ['wasm-emscripten', { kind: 'wasm-emscripten', entry: 'a.html', memory: '256mb' }],
+    ['wasm-rust', { kind: 'wasm-rust', entry: 'a.html' }],
+    ['pyodide', { kind: 'pyodide', entry: 'a.py', packages: ['numpy'] }],
+    ['notebook-html', { kind: 'notebook-html', notebook: 'nb.html' }],
+    ['pglite-db', { kind: 'pglite-db', schema: 'schema.sql', seed: 'seed.sql' }],
+    ['tex-pdf', { kind: 'tex-pdf', pdf: 'paper.pdf' }],
+    ['external-app', { kind: 'external-app', url: 'https://example.com/app' }],
+  ])('accepts %s', (_label, spec) => {
+    expect(EmbedSpec.safeParse(spec).success).toBe(true)
+  })
+
+  it('rejects an unknown kind', () => {
+    expect(EmbedSpec.safeParse({ kind: 'made-up', entry: 'x' }).success).toBe(false)
+  })
+})
+
+describe('Asset', () => {
+  it('parses a minimal asset', () => {
+    const a = { id: 'demo', title: 'Demo', embed: { kind: 'static-html', entry: 'd.html' } }
+    expect(Asset.safeParse(a).success).toBe(true)
+  })
+
+  it('parses with all fields', () => {
+    const a = {
+      id: 'demo',
+      title: 'Demo',
+      description: 'A live demo',
+      group: 'Live demos',
+      embed: { kind: 'static-html', entry: 'd.html' },
+      sizeBytes: 1234,
+    }
+    expect(Asset.safeParse(a).success).toBe(true)
+  })
+
+  it('rejects asset id with uppercase', () => {
+    const a = { id: 'Demo', title: 'D', embed: { kind: 'static-html', entry: 'd.html' } }
+    expect(Asset.safeParse(a).success).toBe(false)
+  })
+
+  it('rejects asset id starting with hyphen', () => {
+    const a = { id: '-demo', title: 'D', embed: { kind: 'static-html', entry: 'd.html' } }
+    expect(Asset.safeParse(a).success).toBe(false)
+  })
+
+  it('rejects asset id over 40 chars', () => {
+    const a = { id: 'a'.repeat(41), title: 'D', embed: { kind: 'static-html', entry: 'd.html' } }
+    expect(Asset.safeParse(a).success).toBe(false)
+  })
+})
+
+describe('normalizeManifest', () => {
+  it('upgrades v1 to v2 shape with one synthesized asset', () => {
+    const parsed = ProjectManifest.parse(v1Sample)
+    const norm = normalizeManifest(parsed)
+    expect(norm.assets).toHaveLength(1)
+    expect(norm.assets[0]!.id).toBe('main')
+    expect(norm.assets[0]!.embed).toEqual(v1Sample.embed)
+    expect(norm.defaultAssetId).toBe('main')
+  })
+
+  it('preserves v1 metadata fields', () => {
+    const parsed = ProjectManifest.parse(v1Sample)
+    const norm = normalizeManifest(parsed)
+    expect(norm.slug).toBe('cse-160')
+    expect(norm.title).toBe(v1Sample.title)
+    expect(norm.description).toBe(v1Sample.description)
+    expect(norm.tags).toEqual(['webgl'])
+    expect(norm.completionLevel).toBe('ships')
+    expect(norm.delivery.version).toBe('abc123')
+  })
+
+  it('passes v2 through with defaultAssetId resolved', () => {
+    const parsed = ProjectManifest.parse(v2Sample)
+    const norm = normalizeManifest(parsed)
+    expect(norm.assets).toHaveLength(3)
+    expect(norm.defaultAssetId).toBe('asg2')
+  })
+
+  it('falls back to first asset when defaultAssetId points to nothing', () => {
+    const v2 = { ...v2Sample, defaultAssetId: 'nonexistent' }
+    const parsed = ProjectManifest.parse(v2)
+    const norm = normalizeManifest(parsed)
+    expect(norm.defaultAssetId).toBe('asg0')
+  })
+
+  it('falls back to first asset when defaultAssetId is omitted', () => {
+    const { defaultAssetId: _, ...rest } = v2Sample
+    void _
+    const parsed = ProjectManifest.parse(rest)
+    const norm = normalizeManifest(parsed)
+    expect(norm.defaultAssetId).toBe('asg0')
+  })
+
+  it('output is idempotent: normalizing a v2 twice yields the same shape', () => {
+    const parsed = ProjectManifest.parse(v2Sample)
+    const once = normalizeManifest(parsed)
+    // Re-parse 'once' as a v2 manifest (with schemaVersion stuffed back)
+    // and normalize again; result should equal the first normalisation.
+    const reparsed = ProjectManifest.parse({ schemaVersion: 2, ...once })
+    const twice = normalizeManifest(reparsed)
+    expect(twice).toEqual(once)
+  })
+})

--- a/src/lib/types/project-manifest.ts
+++ b/src/lib/types/project-manifest.ts
@@ -1,12 +1,27 @@
 /**
  * Project-embed manifest schema (zod).
  *
- * The single source of truth for what `web.codeseys.json` looks like. Mirrored
- * verbatim from the validator in baladithyab/web-embed-workflows so the
- * personal site and the reusable CI workflow agree byte-for-byte on what's
- * accepted.
+ * The single source of truth for what `web.codeseys.json` looks like.
+ * Mirrored verbatim in `baladithyab/web-embed-workflows::scripts/validate-manifest.ts`
+ * so the personal site and the reusable CI workflow agree byte-for-byte on
+ * what's accepted.
  *
  * If you change anything here, change it there too.
+ *
+ * Schema versions
+ * ---------------
+ * - `schemaVersion: 1` — single-asset manifest. Top-level `embed` field is
+ *   the project's only renderable artifact.
+ * - `schemaVersion: 2` — multi-asset manifest. `assets[]` carries N
+ *   independently-renderable artifacts (HTML demo + PDF writeup + WASM
+ *   harness, etc.); the project page renders a tab strip to switch
+ *   between them. Top-level `embed` becomes optional and, when set, is
+ *   treated as the default asset (synthesized into `assets[0]` at parse
+ *   time).
+ *
+ * v1 and v2 manifests are both valid; v1 is upgraded internally to a
+ * v2-shaped `ProjectEntry` so consumers (UI, discovery, content
+ * collection) only have to handle one shape. See `normalizeManifest`.
  *
  * See {@link ../../../docs/PROJECT_EMBEDS.md} for the architecture.
  */
@@ -17,8 +32,8 @@ import { z } from 'astro/zod'
  * Embed renderer flavor. The discriminated union maps 1:1 to the
  * `<EmbedRouter>` switch in `src/components/embeds/EmbedRouter.tsx`.
  *
- * Each variant carries the minimum it needs to construct an artifact URL or
- * spawn a runtime — nothing more.
+ * Each variant carries the minimum it needs to construct an artifact URL
+ * or spawn a runtime — nothing more.
  */
 export const EmbedSpec = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('static-html'), entry: z.string() }),
@@ -43,7 +58,8 @@ export type EmbedSpec = z.infer<typeof EmbedSpec>
 
 /**
  * Project category — informs presentation (school + course code chip,
- * hackathon banner, work-org tag, etc.) without constraining the embed kind.
+ * hackathon banner, work-org tag, etc.) without constraining the embed
+ * kind.
  */
 export const Category = z.discriminatedUnion('kind', [
   z.object({
@@ -61,31 +77,33 @@ export const Category = z.discriminatedUnion('kind', [
 export type Category = z.infer<typeof Category>
 
 /**
- * Delivery mode — decouples *when* the site acquires the artifact (build-time
- * or view-time) from *where* the artifact is served from (same-origin,
- * `assets-r2.codeseys.io`, or external).
+ * Delivery mode — decouples *when* the site acquires the artifact (build-
+ * time or view-time) from *where* the artifact is served from (same-
+ * origin, `assets-r2.codeseys.io`, or external).
  *
- * Renderers don't care which mode is in play; they take a URL prop. The
- * discovery step handles the build-time-vs-runtime distinction.
+ * For multi-asset projects, `delivery.url` is the **shared prefix**
+ * under which every asset's `entry` is resolved. CI always uploads the
+ * whole bundle to `<slug>/<sha>/`; individual assets use relative paths
+ * inside that.
  */
 export const Delivery = z.object({
   mode: z.enum(['bundle', 'runtime-r2', 'runtime-foreign']),
-  /** Absolute URL where the artifact lives. Bundle mode rewrites this to a
-   *  same-origin path during the personal-site prebuild. */
+  /** Absolute URL where the artifact root lives. Bundle mode rewrites
+   *  this to a same-origin path during the personal-site prebuild. */
   url: z.url(),
   /** Git SHA or version tag. Used in R2 paths and for "what version is
    *  rendered?" UI. */
   version: z.string().min(1),
-  /** Reported by the project's CI. Drives the badge that warns about
+  /** Total bytes of the upload. Drives the badge that warns about
    *  download size on slow connections. */
   sizeBytes: z.number().int().min(0),
 })
 export type Delivery = z.infer<typeof Delivery>
 
 /**
- * Build metadata. Kept in the manifest so the personal site can link off to
- * the source workflow file when a curious visitor asks "how is this thing
- * actually built?".
+ * Build metadata. Kept in the manifest so the personal site can link
+ * off to the source workflow file when a curious visitor asks "how is
+ * this thing actually built?".
  */
 export const Build = z.object({
   ci: z.boolean(),
@@ -93,13 +111,38 @@ export const Build = z.object({
 })
 export type Build = z.infer<typeof Build>
 
+/* ─────────────────────── Asset shape (v2) ─────────────────────── */
+
 /**
- * Top-level manifest — the contract every embeddable project commits to.
+ * A single renderable artifact within a project. Used in v2 manifests'
+ * `assets[]`.
  *
- * Slug regex matches the regex enforced by the upload Worker — anything
- * accepted here is acceptable as an upload prefix.
+ * `id` is what shows up in the URL (`?asset=<id>`) and as the tab key.
+ * Must be unique within a project. Shape mirrors a slug: lowercase,
+ * hyphens, ≤40 chars. The empty-default-asset case (a project with one
+ * artifact and no tabs) uses `id: 'main'` by convention.
  */
-export const ProjectManifest = z.object({
+export const Asset = z.object({
+  id: z
+    .string()
+    .regex(/^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/, 'asset id must be lowercase alphanumeric with hyphens, ≤40 chars'),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  /** Optional category tag for grouping ("Demo", "Writeup", "Source", etc.) */
+  group: z.string().optional(),
+  embed: EmbedSpec,
+  /** Bytes for this individual asset (subset of delivery.sizeBytes). */
+  sizeBytes: z.number().int().min(0).optional(),
+})
+export type Asset = z.infer<typeof Asset>
+
+/* ─────────────────────── Top-level manifest ─────────────────────── */
+
+/**
+ * v1 — single-asset manifest. Treated as a v2 manifest with one synthesized
+ * asset internally; v1 source files stay valid and don't need migration.
+ */
+const ProjectManifestV1 = z.object({
   schemaVersion: z.literal(1),
   slug: z
     .string()
@@ -108,20 +151,80 @@ export const ProjectManifest = z.object({
   title: z.string().min(1),
   description: z.string().min(1),
   tags: z.array(z.string()).default([]),
-  /** Optional thumbnail path *relative to the artifact root*. Resolved against
-   *  `delivery.url` at render time so the site doesn't have to mirror it. */
   thumbnail: z.string().optional(),
   completionLevel: z.enum(['wip', 'works', 'ships']),
   embed: EmbedSpec,
   delivery: Delivery,
   build: Build,
 })
-export type ProjectManifest = z.infer<typeof ProjectManifest>
+type ProjectManifestV1 = z.infer<typeof ProjectManifestV1>
 
 /**
- * Discovery metadata that the personal site adds to a manifest *after* it
- * fetches it — never written by the project repo. Tracks which GitHub repo a
- * manifest came from and when we last synced it. Lets the listing page show
+ * v2 — multi-asset manifest. The `assets[]` field carries N
+ * independently-rendered artifacts. Top-level `embed` becomes optional;
+ * when present, it's the default asset.
+ *
+ * `defaultAssetId` is optional and falls back to `assets[0].id`.
+ */
+const ProjectManifestV2 = z.object({
+  schemaVersion: z.literal(2),
+  slug: z
+    .string()
+    .regex(/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/, 'slug must be lowercase, hyphen-separated, ≤64 chars'),
+  category: Category,
+  title: z.string().min(1),
+  description: z.string().min(1),
+  tags: z.array(z.string()).default([]),
+  thumbnail: z.string().optional(),
+  completionLevel: z.enum(['wip', 'works', 'ships']),
+  /** v2's defining field: at least one renderable artifact. */
+  assets: z.array(Asset).min(1, 'v2 manifest must declare at least one asset'),
+  /** Which asset is shown when the visitor lands on /projects/<slug>
+   *  with no `?asset` query param. Defaults to the first asset's id. */
+  defaultAssetId: z.string().optional(),
+  delivery: Delivery,
+  build: Build,
+})
+type ProjectManifestV2 = z.infer<typeof ProjectManifestV2>
+
+/**
+ * Discriminated union accepting either v1 or v2 manifests. Use
+ * `ProjectManifest.safeParse` to validate raw JSON; downstream code
+ * should use `normalizeManifest` to collapse both into a single shape.
+ */
+export const ProjectManifest = z.discriminatedUnion('schemaVersion', [
+  ProjectManifestV1,
+  ProjectManifestV2,
+])
+export type ProjectManifest = z.infer<typeof ProjectManifest>
+
+/* ─────────────────────── Normalised v2 entry ─────────────────────── */
+
+/**
+ * The shape consumers (UI, content collection) actually work with.
+ *
+ * Always v2-shaped: `assets[]` is non-empty, `defaultAssetId` is
+ * resolved. v1 manifests are upgraded by `normalizeManifest`.
+ */
+export const NormalizedManifest = z.object({
+  slug: z.string(),
+  category: Category,
+  title: z.string(),
+  description: z.string(),
+  tags: z.array(z.string()),
+  thumbnail: z.string().optional(),
+  completionLevel: z.enum(['wip', 'works', 'ships']),
+  assets: z.array(Asset).min(1),
+  defaultAssetId: z.string(),
+  delivery: Delivery,
+  build: Build,
+})
+export type NormalizedManifest = z.infer<typeof NormalizedManifest>
+
+/**
+ * Discovery metadata that the personal site adds to a manifest *after*
+ * fetching it — never written by the project repo. Tracks the source
+ * repo and last-sync timestamp so the listing page can show
  * "from baladithyab/UCSC-CSE-160-W21 · synced 2 hours ago".
  */
 export const DiscoveryMetadata = z.object({
@@ -135,10 +238,66 @@ export const DiscoveryMetadata = z.object({
 export type DiscoveryMetadata = z.infer<typeof DiscoveryMetadata>
 
 /**
- * The full content-entry shape: manifest + discovery metadata. This is what
- * Astro's `getCollection('projects')` returns.
+ * Full content-entry shape: normalised v2 manifest + discovery metadata.
+ * What `getCollection('projects')` returns.
  */
-export const ProjectEntry = ProjectManifest.extend({
+export const ProjectEntry = NormalizedManifest.extend({
   discovery: DiscoveryMetadata,
 })
 export type ProjectEntry = z.infer<typeof ProjectEntry>
+
+/* ─────────────────────── Normaliser ─────────────────────── */
+
+/**
+ * Upgrade a v1 manifest to the v2-shaped `NormalizedManifest`. v2
+ * manifests pass through with `defaultAssetId` resolved.
+ *
+ * v1 → v2 strategy: synthesize a single asset with id `'main'` from
+ * the top-level `embed`. The asset takes its `title` from a heuristic:
+ * for `static-html`/`tex-pdf`/etc., we use the project's title; the
+ * embed kind is preserved verbatim.
+ *
+ * This is a pure function; safe to call from the discovery script and
+ * from any astro/vite consumer.
+ */
+export function normalizeManifest(m: ProjectManifest): NormalizedManifest {
+  if (m.schemaVersion === 1) {
+    const asset: Asset = {
+      id: 'main',
+      title: m.title,
+      embed: m.embed,
+      sizeBytes: m.delivery.sizeBytes,
+    }
+    return {
+      slug: m.slug,
+      category: m.category,
+      title: m.title,
+      description: m.description,
+      tags: m.tags,
+      thumbnail: m.thumbnail,
+      completionLevel: m.completionLevel,
+      assets: [asset],
+      defaultAssetId: 'main',
+      delivery: m.delivery,
+      build: m.build,
+    }
+  }
+  // v2: validate that defaultAssetId (if set) matches a real asset.
+  // Fall back to assets[0].id otherwise.
+  const ids = new Set(m.assets.map(a => a.id))
+  const fallback = m.assets[0]!.id
+  const defaultAssetId = m.defaultAssetId && ids.has(m.defaultAssetId) ? m.defaultAssetId : fallback
+  return {
+    slug: m.slug,
+    category: m.category,
+    title: m.title,
+    description: m.description,
+    tags: m.tags,
+    thumbnail: m.thumbnail,
+    completionLevel: m.completionLevel,
+    assets: m.assets,
+    defaultAssetId,
+    delivery: m.delivery,
+    build: m.build,
+  }
+}

--- a/src/pages/api/projects/[slug]/versions.ts
+++ b/src/pages/api/projects/[slug]/versions.ts
@@ -1,0 +1,119 @@
+/**
+ * GET /api/projects/<slug>/versions
+ *
+ * Lists every git-sha version that's currently in R2 for the given slug.
+ * Used by the version picker on `/projects/<slug>` so visitors can flip
+ * between historical builds without leaving the page.
+ *
+ * Implementation: walks `bucket.list({ prefix: '<slug>/' })` with
+ * `delimiter: '/'` so only the next-level prefixes (i.e. the `<sha>/`
+ * directories) come back. Filters out anything that doesn't look like
+ * a git sha or version tag.
+ *
+ * Response:
+ *   { ok: true, slug, versions: [{ id, lastModified?, sizeBytes? }] }
+ *
+ * `versions` is sorted with the newest first (by lastModified of the
+ * most-recently-updated object inside that prefix; this is the best
+ * R2 lets us do without storing version metadata alongside).
+ *
+ * Caching: 5 min edge cache. The version set is stable enough that
+ * stale-by-five-minutes is fine.
+ */
+
+import type { APIRoute } from 'astro'
+
+export const prerender = false
+
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/
+// Versions look like git short-shas (7-40 hex chars) or semver-ish tags.
+const VERSION_RE = /^[a-z0-9._-]{1,64}$/i
+
+interface Env {
+  PROJECT_ASSETS: R2Bucket
+}
+
+interface VersionEntry {
+  id: string
+  lastModified?: string
+  sizeBytes?: number
+}
+
+interface Locals {
+  runtime?: { env?: Partial<Env> }
+}
+
+function envFromLocals(locals: unknown): Env | null {
+  const r = (locals as Locals | undefined)?.runtime?.env
+  if (!r?.PROJECT_ASSETS) return null
+  return { PROJECT_ASSETS: r.PROJECT_ASSETS as R2Bucket }
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=300',
+      ...(init.headers ?? {}),
+    },
+  })
+}
+
+export const GET: APIRoute = async ({ params, locals }) => {
+  const slug = params.slug
+  if (typeof slug !== 'string' || !SLUG_RE.test(slug)) {
+    return jsonResponse({ ok: false, error: 'invalid slug' }, { status: 400 })
+  }
+
+  const env = envFromLocals(locals)
+  if (!env) {
+    // Shouldn't happen in production; surface a clear error during dev
+    // when the binding hasn't been wired up.
+    return jsonResponse({ ok: false, error: 'PROJECT_ASSETS binding unavailable' }, { status: 500 })
+  }
+
+  // Walk one level of prefixes under <slug>/.
+  const prefix = `${slug}/`
+  const versions: Map<string, VersionEntry> = new Map()
+
+  // R2 list is paginated when there are >1000 keys. Multi-asset projects
+  // can easily produce hundreds of objects per version, so we need to
+  // page until the prefixes-set stabilises. Practically, walking until
+  // truncated=false or we hit 100 distinct versions is safe.
+  let cursor: string | undefined
+  let pages = 0
+  /* eslint-disable no-constant-condition */
+  while (true) {
+    pages += 1
+    if (pages > 50) break // hard ceiling, ~50k objects scanned
+    const list = await env.PROJECT_ASSETS.list({
+      prefix,
+      delimiter: '/',
+      cursor,
+      limit: 1000,
+    })
+    // delimitedPrefixes is the list of <slug>/<sha>/ directories.
+    for (const p of list.delimitedPrefixes) {
+      // p looks like "cse-160/abc123/" — extract the version segment.
+      const trimmed = p.slice(prefix.length).replace(/\/+$/, '')
+      if (!trimmed || !VERSION_RE.test(trimmed)) continue
+      if (!versions.has(trimmed)) versions.set(trimmed, { id: trimmed })
+    }
+    // delimitedPrefixes-only listing won't give us per-version size or
+    // mtime. We optionally do a second pass on each version's manifest
+    // file if the project bundles one — but in v1 we don't, and the
+    // ordering returned by R2 is lexicographic which isn't meaningful
+    // for git shas. Leave lastModified/sizeBytes undefined for now.
+    if (!list.truncated) break
+    cursor = list.cursor
+  }
+
+  // Lexicographic order isn't meaningful for git shas — but it IS
+  // deterministic, which is good enough until we wire per-version
+  // mtime probes. The UI shows the manifest's pinned version as the
+  // "current" entry regardless of position in this list.
+  const list = [...versions.values()].sort((a, b) => a.id.localeCompare(b.id))
+
+  return jsonResponse({ ok: true, slug, versions: list })
+}

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -2,31 +2,77 @@
 /**
  * /projects/[slug] — individual project page.
  *
- * Renders the embed via `<EmbedRouter>` plus a sidebar with metadata, tags,
- * source repo link, version pin, and the architecture-doc link. The embed
- * itself is the page's centerpiece — most of the layout is "give the
- * artifact maximum vertical real estate without losing context."
+ * Renders the active asset's embed (selected via `?asset=<id>`, defaults
+ * to `manifest.defaultAssetId`) in the page's centerpiece, with a
+ * sidebar showing project metadata, a tab strip for switching assets,
+ * and a version picker for switching to historical builds.
+ *
+ * Why request-time SSR (not prerender): the page accepts two query
+ * params that affect what it renders:
+ * - `?asset=<id>` — handled client-side by ProjectViewer
+ * - `?v=<sha>` — affects the deliveryUrl that the embed loads from.
+ *   We resolve this server-side so deep-links to old versions render
+ *   the right artifact even if the URL is shared as a static link
+ *   (no JS execution required to see the right thing).
+ *
+ * The Worker is already running for /api/embed-upload and the
+ * /api/projects/[slug]/versions route; one more SSR route is cheap.
  */
 
 import BaseLayout from '@/layouts/BaseLayout.astro'
-import EmbedRouter from '@/components/embeds/EmbedRouter'
+import ProjectViewer from '@/components/embeds/ProjectViewer'
+import VersionPicker from '@/components/embeds/VersionPicker'
 import { getCollection } from 'astro:content'
-import type { GetStaticPaths } from 'astro'
+import { PROJECT_SLUG_REDIRECTS } from '@/lib/project-redirects'
 
-// Prerender per-slug pages at build time. We know every slug at build time
-// (the sync step writes one content entry per discovered manifest), so SSR
-// at request time would just be wasted Worker invocations.
-export const prerender = true
+const { slug } = Astro.params
+if (typeof slug !== 'string' || !slug) {
+  return Astro.redirect('/projects')
+}
 
-export const getStaticPaths = (async () => {
-  const entries = await getCollection('projects')
-  return entries.map((entry) => ({
-    params: { slug: entry.data.slug },
-    props: { entry: entry.data },
-  }))
-}) satisfies GetStaticPaths
+// Slug-rename support: if this slug is a known historical slug, 308 to
+// the canonical one (carrying any query params forward so deep-links to
+// asset/version still work).
+const redirectTarget = PROJECT_SLUG_REDIRECTS[slug]
+if (redirectTarget) {
+  return Astro.redirect(`/projects/${redirectTarget}${Astro.url.search || ''}`, 308)
+}
 
-const { entry } = Astro.props
+const entries = await getCollection('projects')
+const matched = entries.find((e) => e.data.slug === slug)
+if (!matched) {
+  return new Response('Not Found', { status: 404, headers: { 'Content-Type': 'text/plain' } })
+}
+
+const entry = matched.data
+
+// ── version override ─────────────────────────────────────────────
+// `?v=<sha>` swaps the delivery prefix to a historical build. We don't
+// validate against R2 here — if the version doesn't exist, the iframe
+// will 404 and the user can pick another. (We could pre-check by
+// HEAD'ing the bucket, but that's a Worker round-trip per request and
+// not worth it for a portfolio site.)
+const requestedVersion = Astro.url.searchParams.get('v')
+const VERSION_RE = /^[a-z0-9._-]{1,64}$/i
+
+let activeVersion = entry.delivery.version
+let activeDeliveryUrl = entry.delivery.url
+if (requestedVersion && VERSION_RE.test(requestedVersion) && requestedVersion !== entry.delivery.version) {
+  // Replace the version segment in the delivery URL. The convention is
+  // `https://assets-r2.codeseys.io/<slug>/<version>/`; we splice the new
+  // version in. If the URL doesn't match the convention, fall back to
+  // the manifest's URL (visitor sees the canonical version).
+  const u = new URL(entry.delivery.url)
+  const parts = u.pathname.split('/').filter(Boolean) // ['cse-160', '986d88c', ...]
+  if (parts.length >= 2 && parts[0] === entry.slug) {
+    parts[1] = requestedVersion
+    u.pathname = '/' + parts.join('/') + '/'
+    activeDeliveryUrl = u.toString()
+    activeVersion = requestedVersion
+  }
+}
+
+// ── helpers ──────────────────────────────────────────────────────
 
 function categoryLabel(c: typeof entry.category): string {
   switch (c.kind) {
@@ -65,6 +111,8 @@ const dot = completionDot(entry.completionLevel)
 const sourceUrl = `https://github.com/${entry.discovery.source}`
 const ogDescription =
   entry.description.length > 160 ? entry.description.slice(0, 157).trimEnd() + '…' : entry.description
+
+const isStaleVersion = activeVersion !== entry.delivery.version
 ---
 
 <BaseLayout
@@ -96,26 +144,40 @@ const ogDescription =
       </div>
     </header>
 
-    <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
-      {/* Embed — the whole point of the page */}
-      <div class="min-w-0">
-        <EmbedRouter entry={entry} client:load />
+    {
+      isStaleVersion && (
+        <div class="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs">
+          <span class="text-amber-200">
+            Viewing historical version <code class="font-mono font-semibold">{activeVersion}</code> — current is <code class="font-mono font-semibold">{entry.delivery.version}</code>.
+          </span>
+          <a class="font-medium text-amber-200 underline-offset-2 hover:underline" href={`/projects/${entry.slug}`}>
+            Jump to current
+          </a>
+        </div>
+      )
+    }
 
-        {/* Tags */}
-        {
-          entry.tags.length > 0 && (
-            <div class="mt-4 flex flex-wrap gap-1.5">
-              {entry.tags.map((tag) => (
-                <span class="inline-flex items-center rounded-md border bg-background/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )
-        }
+    <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
+      {/* Embed centerpiece — asset tab strip + active embed */}
+      <div class="min-w-0">
+        <ProjectViewer
+          assets={entry.assets}
+          defaultAssetId={entry.defaultAssetId}
+          deliveryUrl={activeDeliveryUrl}
+          client:load
+        />
+
+        {entry.tags.length > 0 && (
+          <div class="mt-4 flex flex-wrap gap-1.5">
+            {entry.tags.map((tag) => (
+              <span class="inline-flex items-center rounded-md border bg-background/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
-      {/* Sidebar — metadata, links */}
       <aside class="space-y-4 text-sm">
         <div class="rounded-xl border bg-card p-4">
           <h2 class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -152,30 +214,34 @@ const ogDescription =
           </h2>
           <dl class="space-y-2 text-xs">
             <div class="flex items-baseline justify-between gap-2">
-              <dt class="text-muted-foreground">Embed</dt>
-              <dd class="font-mono text-foreground">{entry.embed.kind}</dd>
+              <dt class="text-muted-foreground">Assets</dt>
+              <dd class="font-mono text-foreground">{entry.assets.length}</dd>
             </div>
             <div class="flex items-baseline justify-between gap-2">
               <dt class="text-muted-foreground">Delivery</dt>
               <dd class="font-mono text-foreground">{entry.delivery.mode}</dd>
             </div>
             <div class="flex items-baseline justify-between gap-2">
-              <dt class="text-muted-foreground">Version</dt>
+              <dt class="text-muted-foreground">Pinned</dt>
               <dd class="font-mono text-foreground">{entry.delivery.version}</dd>
             </div>
             <div class="flex items-baseline justify-between gap-2">
-              <dt class="text-muted-foreground">Size</dt>
+              <dt class="text-muted-foreground">Total size</dt>
               <dd class="font-mono text-foreground">{formatBytes(entry.delivery.sizeBytes)}</dd>
             </div>
           </dl>
-          <a
-            href={entry.delivery.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="mt-3 inline-block break-all font-mono text-[10px] text-muted-foreground hover:text-primary"
-          >
-            {entry.delivery.url}
-          </a>
+        </div>
+
+        <div class="rounded-xl border bg-card p-4">
+          <h2 class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Versions
+          </h2>
+          <VersionPicker
+            slug={entry.slug}
+            currentVersion={entry.delivery.version}
+            activeVersion={activeVersion}
+            client:load
+          />
         </div>
 
         <div class="rounded-xl border bg-card p-4">

--- a/src/scripts/sync-project-manifests.ts
+++ b/src/scripts/sync-project-manifests.ts
@@ -23,7 +23,7 @@ import { existsSync } from 'node:fs'
 import { mkdir, readdir, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 
-import { ProjectManifest } from '../lib/types/project-manifest.ts'
+import { ProjectManifest, normalizeManifest } from '../lib/types/project-manifest.ts'
 
 const TOPIC = 'codeseys-embed'
 const OUT_DIR = resolve(process.cwd(), 'src/content/projects')
@@ -156,8 +156,12 @@ async function clearExisting(): Promise<void> {
 }
 
 async function writeEntry(entry: ValidEntry): Promise<void> {
+  // Normalise v1 → v2 shape before writing so the content collection only
+  // ever holds v2-shaped entries. UI code never has to branch on
+  // schemaVersion.
+  const normalized = normalizeManifest(entry.manifest)
   const out = {
-    ...entry.manifest,
+    ...normalized,
     discovery: {
       source: entry.source,
       ref: entry.ref,
@@ -165,7 +169,7 @@ async function writeEntry(entry: ValidEntry): Promise<void> {
     },
   }
   await mkdir(OUT_DIR, { recursive: true })
-  await writeFile(join(OUT_DIR, `${entry.manifest.slug}.json`), JSON.stringify(out, null, 2) + '\n')
+  await writeFile(join(OUT_DIR, `${normalized.slug}.json`), JSON.stringify(out, null, 2) + '\n')
 }
 
 /* ────────────────────────────── main ─────────────────────────────── */


### PR DESCRIPTION
## Summary

Adds the personal-site half of the multi-asset + versioning upgrade. A project's `/projects/<slug>` page can now carry N assets (HTML demos, PDF writeups, future WASM harnesses) under a tab strip, plus a sidebar version picker showing every R2 build the project has produced so visitors can flip back to old versions.

## Companion PRs (already merged)

- `baladithyab/web-embed-workflows@dd79f8a` — workflow accepts v2 multi-asset manifests
- `baladithyab/UCSC-CSE-160-W21@941572c` — migrated to v2; 7 assets live (asg0/asg1/asg2 demos + 4 LaTeX PDFs)

## Live behaviour after deploy

| URL | What renders |
|---|---|
| `/projects/cse-160` | Default asset (asg2 — Charmeleon) with tab strip showing all 7 |
| `/projects/cse-160?asset=hw1` | Linear-algebra LaTeX writeup PDF |
| `/projects/cse-160?v=986d88c` | Previous build of every asset, with "viewing historical" banner |
| `/projects/cse-160-asg2` | 308 → `/projects/cse-160` (slug-rename redirect) |

## Schema v2

`ProjectManifestV2` adds `assets[]` + optional `defaultAssetId`. v1 manifests stay valid — `normalizeManifest` upgrades them to a v2-shaped `NormalizedManifest` with one synthesized asset (`id: 'main'`).

## Components

- `AssetTabs.tsx` + `useAssetSelection` — `?asset=<id>` URL binding, modifier-click respected.
- `ProjectViewer.tsx` — combined island for tab strip + active embed (shared state).
- `VersionPicker.tsx` — sidebar widget, lazy-fetches `/api/projects/<slug>/versions`.
- `/api/projects/[slug]/versions` — Worker route walking R2 list with delimiter.
- `/projects/[slug].astro` — flipped to request-time SSR so `?v=<sha>` can swap delivery URL prefix.
- `project-redirects.ts` — slug-rename map (first entry: `cse-160-asg2 → cse-160`).

## Verification

- `bun run test` → 147/147 (was 120, +27 in `project-manifest.test.ts`)
- `bun run astro check` → 0/0/0
- All 7 assets reachable on R2 with correct content types
