### PR TITLE
fix(blog): strip mermaid's baked <style> at build time (ROOT CAUSE of white blocks)

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -89,6 +89,30 @@ function rehypeMermaidNormalize() {
         node.properties.style = `width:${intrinsicW}px;height:${intrinsicH}px`
       }
 
+      // Strip the `<style>` element that mermaid bakes into every SVG. It
+      // contains ~40 ID-scoped rules like
+      //   #mermaid-0 .edgeLabel p { background-color: white }
+      //   #mermaid-0 .node rect { fill: #eee; stroke: #999 }
+      // ID specificity (1,0,0) beats every class-scoped selector (max
+      // 0,3,2) we can write from outside, so as long as that style block
+      // exists, our theme overrides lose the cascade and edge-label
+      // backplates show as white blocks on dark mode (and vice-versa).
+      // Stripping it here means our CSS in `[slug].astro` owns the entire
+      // palette — no specificity arms-race, no `!important` games.
+      //
+      // Side effect: we also lose mermaid's defaults for things our CSS
+      // doesn't touch (font-family, edge-animation keyframes, .marker
+      // fill, .arrowheadPath fill, .cluster styling, neo-look filters).
+      // We explicitly cover the visible ones in `[slug].astro` under
+      // "Replacements for the mermaid-baked <style> element". The
+      // animation keyframes go unused because we don't emit
+      // `.edge-animation-*` classes.
+      if (Array.isArray(node.children)) {
+        node.children = node.children.filter(
+          (c: any) => !(c?.type === 'element' && c?.tagName === 'style'),
+        )
+      }
+
       // Wrap the SVG in <div class="mermaid-frame"> for horizontal scroll on
       // overflow. We can't safely insert siblings via visit, so we mutate the
       // current node into the wrapper and put the original SVG inside.

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -275,6 +275,48 @@ const otherPosts = sortBlogPosts(
      `:global()` wrapping needed (Astro emits that as literal text, which
      browsers drop as an unknown pseudo). */
 
+  /* ─────────────────────────────────────────────────────────────────────
+     Replacements for the mermaid-baked `<style>` element that we strip in
+     `astro.config.ts` (`rehypeMermaidNormalize`). Mermaid normally injects
+     ~40 ID-scoped rules into each SVG; we strip those because their ID
+     specificity (1,0,0) made it impossible to theme the diagram from
+     outside. The rules below cover the visible defaults we actually need
+     (font-family, foreignObject p margin/bg reset, cluster styling).
+     Anything not listed here was either invisible-by-default,
+     animation-only, or covered by the theme blocks further down.
+     ───────────────────────────────────────────────────────────────────── */
+  .mermaid-frame svg[id^='mermaid-'] {
+    font-family: ui-sans-serif, system-ui, sans-serif;
+  }
+  /* Mermaid normally resets `<p>` margin via `#mermaid-N p { margin: 0 }`
+     and paints `.edgeLabel p { background-color: white }`. With the
+     embedded style stripped, the browser's default 1em margin would push
+     labels out of their bounding boxes — and the white background would
+     return as the prose `<p>` styling cascades in. Reset both at the
+     foreignObject root. */
+  .mermaid-frame svg[id^='mermaid-'] foreignObject p,
+  .mermaid-frame svg[id^='mermaid-'] foreignObject div {
+    margin: 0 !important;
+    background-color: transparent !important;
+  }
+  /* Cluster (subgraph) backgrounds — mermaid baked these as
+     `hsl(0, 0%, 98.9%)` (near-white). Use --muted/40 so they're visible
+     in both modes without dominating. */
+  .mermaid-frame svg[id^='mermaid-'] .cluster rect {
+    fill: hsl(var(--muted) / 0.4) !important;
+    stroke: hsl(var(--border)) !important;
+    stroke-width: 1px !important;
+  }
+  .mermaid-frame svg[id^='mermaid-'] .cluster text,
+  .mermaid-frame svg[id^='mermaid-'] .cluster span,
+  .mermaid-frame svg[id^='mermaid-'] .cluster-label text,
+  .mermaid-frame svg[id^='mermaid-'] .cluster-label span,
+  .mermaid-frame svg[id^='mermaid-'] .cluster-label span p {
+    fill: hsl(var(--foreground)) !important;
+    color: hsl(var(--foreground)) !important;
+    background-color: transparent !important;
+  }
+
   /* Floating labels in sequence diagrams (text that sits OVER the page bg). */
   .dark .mermaid-frame svg[id^='mermaid-'] .messageText,
   .dark .mermaid-frame svg[id^='mermaid-'] .messageText > tspan,


### PR DESCRIPTION
## TL;DR

Real root cause of the white-block-over-edge-labels bug: mermaid bakes ~40 ID-scoped CSS rules into a `<style>` element INSIDE every rendered SVG. The worst:

```
#mermaid-0 .edgeLabel p { background-color: white }
#mermaid-0 .edgeLabel rect { opacity:0.5; background-color: white; fill: white }
#mermaid-0 .labelBkg { background-color: rgba(255,255,255,0.5) }
#mermaid-0 .node rect { fill: #eee; stroke: #999 }
```

ID specificity (1,0,0) beats every class-scoped selector (max 0,3,2) we can write from outside. **My previous 3 PRs (#22, #23, #25) were all fighting downstream of the real source** — they fixed adjacent issues (modal scoping, stale legacy block) but left mermaid's ID-scoped `#mermaid-0 .edgeLabel p { bg: white }` intact. That `<p>` rendering with a white bg was always going to win against my outer `.dark .mermaid-frame .edgeLabel` rules.

Worse: my computed-style probes on `.labelBkg` returned correct values (slate-950 in dark) — but I was probing the wrong element. The white came from the `<p>` inside the SPAN, not the `.labelBkg` div.

## Fix

**astro.config.ts**: `rehypeMermaidNormalize` now strips the `<style>` child of every SVG at build time. Our class-scoped CSS owns the entire palette, no specificity arms-race.

**[slug].astro**: Added a small replacements block for the visible defaults we lose:
- font-family stack on the SVG itself
- `foreignObject p/div { margin: 0; background: transparent }` ← actually kills the white blocks
- cluster (subgraph) styling via `--muted` / `--foreground`

## Verified
- `bun run build` green
- Will visually verify on live site (vision, not computed-style probes) after deploy