### PR TITLE
fix(api): use cloudflare:workers env import in versions endpoint

### DIFF
--- a/src/pages/api/projects/[slug]/versions.ts
+++ b/src/pages/api/projects/[slug]/versions.ts
@@ -22,6 +22,7 @@
  */
 
 import type { APIRoute } from 'astro'
+import { getRuntimeEnv } from '@/lib/runtime-env'
 
 export const prerender = false
 
@@ -30,23 +31,13 @@ const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/
 const VERSION_RE = /^[a-z0-9._-]{1,64}$/i
 
 interface Env {
-  PROJECT_ASSETS: R2Bucket
+  PROJECT_ASSETS?: R2Bucket
 }
 
 interface VersionEntry {
   id: string
   lastModified?: string
   sizeBytes?: number
-}
-
-interface Locals {
-  runtime?: { env?: Partial<Env> }
-}
-
-function envFromLocals(locals: unknown): Env | null {
-  const r = (locals as Locals | undefined)?.runtime?.env
-  if (!r?.PROJECT_ASSETS) return null
-  return { PROJECT_ASSETS: r.PROJECT_ASSETS as R2Bucket }
 }
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -60,18 +51,19 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   })
 }
 
-export const GET: APIRoute = async ({ params, locals }) => {
+export const GET: APIRoute = async ({ params }) => {
   const slug = params.slug
   if (typeof slug !== 'string' || !SLUG_RE.test(slug)) {
     return jsonResponse({ ok: false, error: 'invalid slug' }, { status: 400 })
   }
 
-  const env = envFromLocals(locals)
-  if (!env) {
+  const env = getRuntimeEnv<Env>()
+  if (!env.PROJECT_ASSETS) {
     // Shouldn't happen in production; surface a clear error during dev
     // when the binding hasn't been wired up.
     return jsonResponse({ ok: false, error: 'PROJECT_ASSETS binding unavailable' }, { status: 500 })
   }
+  const bucket = env.PROJECT_ASSETS
 
   // Walk one level of prefixes under <slug>/.
   const prefix = `${slug}/`
@@ -87,7 +79,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
   while (true) {
     pages += 1
     if (pages > 50) break // hard ceiling, ~50k objects scanned
-    const list = await env.PROJECT_ASSETS.list({
+    const list = await bucket.list({
       prefix,
       delimiter: '/',
       cursor,
@@ -100,11 +92,6 @@ export const GET: APIRoute = async ({ params, locals }) => {
       if (!trimmed || !VERSION_RE.test(trimmed)) continue
       if (!versions.has(trimmed)) versions.set(trimmed, { id: trimmed })
     }
-    // delimitedPrefixes-only listing won't give us per-version size or
-    // mtime. We optionally do a second pass on each version's manifest
-    // file if the project bundles one — but in v1 we don't, and the
-    // ordering returned by R2 is lexicographic which isn't meaningful
-    // for git shas. Leave lastModified/sizeBytes undefined for now.
     if (!list.truncated) break
     cursor = list.cursor
   }
@@ -113,7 +100,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
   // deterministic, which is good enough until we wire per-version
   // mtime probes. The UI shows the manifest's pinned version as the
   // "current" entry regardless of position in this list.
-  const list = [...versions.values()].sort((a, b) => a.id.localeCompare(b.id))
+  const out = [...versions.values()].sort((a, b) => a.id.localeCompare(b.id))
 
-  return jsonResponse({ ok: true, slug, versions: list })
+  return jsonResponse({ ok: true, slug, versions: out })
 }


### PR DESCRIPTION
Astro 6 + @astrojs/cloudflare 13 removed `Astro.locals.runtime.env` in favor of `import { env } from 'cloudflare:workers'`. The versions endpoint was using the deprecated path → 500 in production. Switches to `getRuntimeEnv<Env>()` like `/api/embed-upload` already does. 147/147 tests pass, 0/0/0 astro check.