### PR TITLE
qa(blog): add draft mermaid stress-test post

### DIFF
--- a/src/content/blog/qa-mermaid-stress-test.mdx
+++ b/src/content/blog/qa-mermaid-stress-test.mdx
@@ -1,0 +1,149 @@
+---
+title: 'QA: mermaid theme stress-test (subgraphs, sequence, classDef, notes)'
+description: 'Internal verification page for mermaid theming across diagram types — subgraph backgrounds, sequence diagram notes/loops, classDef overrides, large flowcharts. Draft, not listed.'
+publishedAt: '2026-05-27'
+tags: ['meta', 'qa', 'mermaid']
+draft: true
+featured: false
+---
+
+Internal QA page. Each diagram exercises a different code path that the
+mermaid `<style>` strip + theme replacements need to handle. If anything
+here renders with white blocks, washed-out fills, or unreadable labels in
+either light or dark mode, the issue is upstream of any individual diagram
+and the theme rules in `[slug].astro` need a follow-up.
+
+## 1. Flowchart with two subgraphs
+
+Standard subgraph layout — should render with `--muted/0.4` cluster
+backgrounds and `--foreground` cluster labels, with all node + edge
+styling matching the unified theme.
+
+```mermaid
+flowchart LR
+  Start([Request arrives]) --> Auth{Authenticated?}
+  Auth -->|yes| Cache
+  Auth -->|no| Login
+
+  subgraph EdgeWorker["Edge Worker (Cloudflare)"]
+    direction TB
+    Cache[KV cache lookup] -->|hit| Respond[Return cached]
+    Cache -->|miss| Origin
+    Origin[Fetch origin] --> Store[Write KV] --> Respond
+  end
+
+  subgraph Origin_Stack["Origin (Astro SSR)"]
+    direction TB
+    Login[Login redirect] --> SSR[SSR render] --> DB[(D1)]
+  end
+
+  Respond --> Done([200 OK])
+```
+
+## 2. Nested subgraphs
+
+Subgraph-inside-subgraph — checks that nested cluster backgrounds layer
+correctly and don't cancel each other's tinting.
+
+```mermaid
+flowchart TB
+  subgraph Outer["Production"]
+    direction LR
+    LB[Load balancer]
+    subgraph Inner1["Region: us-west"]
+      A1[Worker A] --> A2[Worker B]
+    end
+    subgraph Inner2["Region: eu-west"]
+      B1[Worker C] --> B2[Worker D]
+    end
+    LB --> A1
+    LB --> B1
+  end
+```
+
+## 3. Sequence diagram with notes + loops
+
+Sequence path uses different elements: `rect.actor`, `text.actor`,
+`.messageText`, `.loopText`, `.noteText`, plus actor lifelines. Should
+all read against both backgrounds.
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Worker
+  participant KV
+  participant Origin
+
+  Client->>Worker: GET /api/profile
+  activate Worker
+  Note over Worker,KV: Cache check first
+
+  Worker->>KV: get(profile:user-42)
+  KV-->>Worker: null (miss)
+
+  loop Retry up to 3 times
+    Worker->>Origin: GET /profile/42
+    alt origin healthy
+      Origin-->>Worker: 200 + JSON
+    else origin 5xx
+      Origin-->>Worker: 502
+    end
+  end
+
+  Worker->>KV: put(profile:user-42, json)
+  Worker-->>Client: 200 + JSON
+  deactivate Worker
+
+  Note right of Client: Subsequent requests<br/>hit KV in <5ms
+```
+
+## 4. classDef styling
+
+Some posts use `classDef` to color-code specific nodes (e.g. critical-path
+in red, async edges in blue). Verify our outer theme doesn't clobber the
+custom `style:` declarations on these nodes — they should keep their
+declared colors.
+
+```mermaid
+flowchart LR
+  A[Normal node] --> B[Normal node]
+  B --> C[Critical]:::critical
+  B --> D[Async]:::async
+  C --> E[Normal end]
+  D --> E
+
+  classDef critical fill:#7f1d1d,stroke:#fca5a5,color:#fff
+  classDef async fill:#1e3a8a,stroke:#93c5fd,color:#fff
+```
+
+## 5. Wide flowchart (overflow scroll test)
+
+Diagrams wider than the prose column should horizontal-scroll, not
+shrink-fit. Edge labels along the path should remain readable as they
+scroll past.
+
+```mermaid
+flowchart LR
+  S1[Stage 1] --> S2[Stage 2] --> S3[Stage 3] --> S4[Stage 4] --> S5[Stage 5]
+  S5 --> S6[Stage 6] --> S7[Stage 7] --> S8[Stage 8] --> S9[Stage 9]
+  S9 --> S10[Stage 10] --> S11[Stage 11] --> S12[Stage 12]
+  S1 -.->|skip| S6
+  S6 -.->|skip| S12
+```
+
+## 6. State diagram (different element set)
+
+State diagrams use yet another element set (`state` shape, transition
+arrows). Should still inherit the unified theme.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Loading: fetch()
+  Loading --> Success: 200
+  Loading --> Error: 4xx/5xx
+  Success --> Idle: dismiss
+  Error --> Loading: retry
+  Error --> Idle: give up
+  Success --> [*]
+```


### PR DESCRIPTION
Draft QA post exercising 6 different mermaid diagram types to verify the embedded-style strip fix from #26 holds across all of them. Will use the preview deploy URL to vision-verify, then either land or remove based on results.