### PR TITLE
feat(projects): overview rendering + View on GitHub button + optional assets/build-step

### DIFF
--- a/src/lib/project-overview.test.ts
+++ b/src/lib/project-overview.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { fetchRenderedOverview, stripFirstH1 } from './project-overview'
+
+describe('stripFirstH1', () => {
+  it('drops a leading H1', () => {
+    const r = stripFirstH1('# CSE 101\n\nWelcome to CSE 101.\n')
+    expect(r).toBe('Welcome to CSE 101.\n')
+  })
+  it('keeps subsequent H1s', () => {
+    const r = stripFirstH1('# Top\n\nbody\n# Another\n')
+    expect(r).toContain('# Another')
+    expect(r).not.toMatch(/^# Top/)
+  })
+  it('passes through if no leading H1', () => {
+    const r = stripFirstH1('Welcome\n\n## Subsection')
+    expect(r).toBe('Welcome\n\n## Subsection')
+  })
+  it('tolerates leading whitespace before H1', () => {
+    const r = stripFirstH1('   \n# Title\n\nbody')
+    expect(r).toBe('body')
+  })
+})
+
+describe('fetchRenderedOverview', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('rejects bogus source format', async () => {
+    const r = await fetchRenderedOverview({
+      source: 'not a slash path',
+      ref: 'main',
+      path: 'README.md',
+      skipFirstHeading: true,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/invalid source/)
+  })
+
+  it('rejects path traversal', async () => {
+    const r = await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'main',
+      path: '../../etc/passwd',
+      skipFirstHeading: true,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/invalid path/)
+  })
+
+  it('rejects absolute paths', async () => {
+    const r = await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'main',
+      path: '/README.md',
+      skipFirstHeading: true,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/invalid path/)
+  })
+
+  it('renders fetched markdown to HTML', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response('# Title\n\nHello **world**.\n\n```js\nconst x = 1\n```', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      })
+    ) as unknown as typeof fetch
+
+    const r = await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'main',
+      path: 'README.md',
+      skipFirstHeading: true,
+    })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      // skipFirstHeading dropped the H1
+      expect(r.html).not.toContain('<h1>Title</h1>')
+      expect(r.html).toContain('<strong>world</strong>')
+      expect(r.html).toMatch(/<code[^>]*>const x = 1/)
+    }
+  })
+
+  it('keeps the first H1 when skipFirstHeading is false', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response('# Title\n\nbody', { status: 200 })
+    ) as unknown as typeof fetch
+
+    const r = await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'main',
+      path: 'README.md',
+      skipFirstHeading: false,
+    })
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.html).toContain('<h1>Title</h1>')
+  })
+
+  it('reports HTTP errors as {ok: false}', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response('Not Found', { status: 404 })
+    ) as unknown as typeof fetch
+
+    const r = await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'main',
+      path: 'README.md',
+      skipFirstHeading: true,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/HTTP 404/)
+  })
+
+  it('rejects empty content', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch
+
+    const r = await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'main',
+      path: 'README.md',
+      skipFirstHeading: true,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/empty/)
+  })
+
+  it('rejects oversized content (>256KB)', async () => {
+    const big = 'x'.repeat(257 * 1024)
+    globalThis.fetch = vi.fn(async () => new Response(big, { status: 200 })) as unknown as typeof fetch
+
+    const r = await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'main',
+      path: 'README.md',
+      skipFirstHeading: true,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/exceeds/)
+  })
+
+  it('handles fetch throwing', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+
+    const r = await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'main',
+      path: 'README.md',
+      skipFirstHeading: true,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/fetch failed/)
+  })
+
+  it('uses raw.githubusercontent.com URL with the right ref + path', async () => {
+    let calledUrl: string | URL = ''
+    globalThis.fetch = vi.fn(async (url) => {
+      calledUrl = typeof url === 'string' ? url : url instanceof URL ? url.href : (url as Request).url
+      return new Response('# X\nbody', { status: 200 })
+    }) as unknown as typeof fetch
+
+    await fetchRenderedOverview({
+      source: 'baladithyab/UCSC-CSE-160-W21',
+      ref: 'master',
+      path: 'docs/OVERVIEW.md',
+      skipFirstHeading: true,
+    })
+    expect(String(calledUrl)).toBe(
+      'https://raw.githubusercontent.com/baladithyab/UCSC-CSE-160-W21/master/docs/OVERVIEW.md'
+    )
+  })
+})

--- a/src/lib/project-overview.ts
+++ b/src/lib/project-overview.ts
@@ -1,0 +1,133 @@
+/**
+ * Project overview fetcher: pulls the README (or whatever path the
+ * manifest declares) from a public GitHub repo and renders it as HTML.
+ *
+ * Why this exists separate from the discovery script:
+ * - Discovery runs at build; READMEs change more often than deploys.
+ *   Fetching at request time keeps the overview fresh without a deploy
+ *   on every README edit.
+ * - Cloudflare's edge cache absorbs the per-request cost — a `Cache-Control`
+ *   header on this fetch lets the same edge serve hundreds of identical
+ *   responses without re-hitting GitHub.
+ *
+ * Design choices:
+ * - We fetch the **raw** content from `raw.githubusercontent.com` rather
+ *   than the API. No auth required for public repos, no rate-limit
+ *   anxiety, fewer moving parts.
+ * - We render with `marked` because it's a) tiny, b) sync, c) Worker-safe
+ *   (no Node-only deps). For our portfolio narrative use case we don't
+ *   need a full MDX runtime — README markdown plus syntax highlighting.
+ * - We optionally strip the first H1 because the page already shows the
+ *   project title (avoids visual duplication). The manifest's
+ *   `overview.skipFirstHeading` controls this.
+ * - Failure is non-fatal: the page renders an "overview unavailable"
+ *   notice with a link to the repo. A broken README never breaks the
+ *   project page.
+ */
+import { marked } from 'marked'
+
+export type FetchOverviewArgs = {
+  /** `<owner>/<name>`, e.g. `baladithyab/UCSC-CSE-160-W21`. */
+  source: string
+  /** Branch ref to fetch from. */
+  ref: string
+  /** Path inside the repo, e.g. `README.md`. */
+  path: string
+  /** Drop the first H1 if present. */
+  skipFirstHeading: boolean
+}
+
+export type FetchOverviewResult =
+  | { ok: true; html: string; rawLen: number }
+  | { ok: false; error: string }
+
+/** Cache TTL for the edge response (5 min). */
+const EDGE_CACHE_TTL = 300
+
+/**
+ * Strip the first H1 from a markdown document if present.
+ * Tolerant to leading whitespace and trailing slug-anchors.
+ */
+export function stripFirstH1(md: string): string {
+  // Match a leading `# Heading` line (with optional newline before).
+  const re = /^\s*#\s+[^\n]+\n+/
+  return md.replace(re, '')
+}
+
+/**
+ * Configure marked to be Worker-safe (no async, no fs).
+ * Done once at module load; safe to call multiple times.
+ */
+let configured = false
+function configureMarked() {
+  if (configured) return
+  marked.setOptions({
+    gfm: true,
+    breaks: false,
+    // No HTML sanitisation here — we trust READMEs from our own repos.
+    // If we ever expand to render third-party READMEs, swap in DOMPurify.
+  })
+  configured = true
+}
+
+/**
+ * Fetch and render an overview document. Always returns; errors come
+ * back as `{ ok: false, error }`. The caller renders an inline notice
+ * for the failure case.
+ */
+export async function fetchRenderedOverview(args: FetchOverviewArgs): Promise<FetchOverviewResult> {
+  configureMarked()
+  const { source, ref, path, skipFirstHeading } = args
+
+  // Validate — defensive against manifest typos that could cause SSRF.
+  if (!/^[\w.-]+\/[\w.-]+$/.test(source)) {
+    return { ok: false, error: `invalid source format: ${source}` }
+  }
+  if (path.includes('..') || path.startsWith('/')) {
+    return { ok: false, error: `invalid path: ${path}` }
+  }
+
+  const rawUrl = `https://raw.githubusercontent.com/${source}/${ref}/${path}`
+
+  let resp: Response
+  try {
+    resp = await fetch(rawUrl, {
+      headers: { Accept: 'text/plain, text/markdown' },
+      cf: {
+        cacheTtl: EDGE_CACHE_TTL,
+        cacheEverything: true,
+      },
+    } as RequestInit)
+  } catch (err) {
+    return {
+      ok: false,
+      error: `fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+
+  if (!resp.ok) {
+    return { ok: false, error: `HTTP ${resp.status} fetching ${path}` }
+  }
+  const md = await resp.text()
+  if (md.length === 0) {
+    return { ok: false, error: `${path} is empty` }
+  }
+  // Cap the rendered size to keep one project's bloated README from
+  // blowing up our SSR response.
+  const MAX_BYTES = 256 * 1024
+  if (md.length > MAX_BYTES) {
+    return { ok: false, error: `${path} exceeds ${MAX_BYTES} bytes` }
+  }
+
+  const sourceMarkdown = skipFirstHeading ? stripFirstH1(md) : md
+  let html: string
+  try {
+    html = await Promise.resolve(marked.parse(sourceMarkdown))
+  } catch (err) {
+    return {
+      ok: false,
+      error: `markdown render failed: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+  return { ok: true, html, rawLen: md.length }
+}

--- a/src/lib/types/project-manifest.test.ts
+++ b/src/lib/types/project-manifest.test.ts
@@ -75,9 +75,20 @@ describe('ProjectManifest schema', () => {
     }
   })
 
-  it('rejects a v2 manifest with no assets', () => {
-    const bad = { ...v2Sample, assets: [] }
-    expect(ProjectManifest.safeParse(bad).success).toBe(false)
+  it('accepts a v2 manifest with no assets (overview-only)', () => {
+    // The 2026-05-28 update made `assets` optional so projects can have
+    // a personal-site page even with no live demo. The normalizer turns
+    // a missing `assets` into an empty array; an empty array passes too.
+    const overviewOnly = { ...v2Sample, assets: [], delivery: undefined, build: undefined }
+    expect(ProjectManifest.safeParse(overviewOnly).success).toBe(true)
+  })
+
+  it('also accepts a v2 manifest with assets omitted entirely', () => {
+    const omitted: Record<string, unknown> = { ...v2Sample }
+    delete omitted.assets
+    delete omitted.delivery
+    delete omitted.build
+    expect(ProjectManifest.safeParse(omitted).success).toBe(true)
   })
 
   it('rejects a v2 manifest with a duplicate-id asset', () => {

--- a/src/lib/types/project-manifest.ts
+++ b/src/lib/types/project-manifest.ts
@@ -104,10 +104,26 @@ export type Delivery = z.infer<typeof Delivery>
  * Build metadata. Kept in the manifest so the personal site can link
  * off to the source workflow file when a curious visitor asks "how is
  * this thing actually built?".
+ *
+ * Optional `script` field: when present, the reusable build workflow
+ * runs `./<script>` BEFORE upload. The script's job is to transform
+ * source → upload-ready artifacts (e.g. compile WASM, optimize media,
+ * convert notebooks to HTML, run TypeScript build).
+ *
+ * The script runs in the repo root with the standard Actions ubuntu-24
+ * runner. Anything in `apt-get install` from a prior step is available;
+ * common tools (ffmpeg, jq, python3, node, bun, rustc) are pre-installed.
+ *
+ * Convention: write the build outputs into `${{ inputs.source-dir }}`
+ * (default `.`), since that's what the upload step rsyncs from.
  */
 export const Build = z.object({
   ci: z.boolean(),
   workflow: z.string().optional(),
+  /** Optional pre-upload transform script, e.g. `scripts/build-embeds.sh`. */
+  script: z.string().optional(),
+  /** Optional list of apt packages to install before running the script. */
+  aptPackages: z.array(z.string()).optional(),
 })
 export type Build = z.infer<typeof Build>
 
@@ -160,11 +176,35 @@ const ProjectManifestV1 = z.object({
 type ProjectManifestV1 = z.infer<typeof ProjectManifestV1>
 
 /**
+ * Optional overview source pointer. Lets the project page render a
+ * narrative section above the embed (or in place of it for projects
+ * with no live demo).
+ *
+ * If absent, the personal site falls back to `README.md` from the
+ * source repo. If present, it overrides that default.
+ *
+ * `skipFirstHeading` drops the leading `# Title` since the page already
+ * shows the manifest's title — avoids visual duplication.
+ */
+const OverviewSource = z.object({
+  /** Path within the source repo, e.g. `README.md` or `docs/OVERVIEW.md`. */
+  path: z.string().min(1).default('README.md'),
+  /** Drop the first H1 if present, since the page already renders the title. */
+  skipFirstHeading: z.boolean().default(true),
+})
+
+/**
  * v2 — multi-asset manifest. The `assets[]` field carries N
  * independently-rendered artifacts. Top-level `embed` becomes optional;
  * when present, it's the default asset.
  *
  * `defaultAssetId` is optional and falls back to `assets[0].id`.
+ *
+ * **`assets`, `delivery`, and `build` became optional** in the
+ * 2026-05-28 update so a project can have a personal-site page even
+ * with no live demo (just an overview + GitHub link). Projects that
+ * declare no assets render an "Overview" view with the README as
+ * centerpiece and no embed sandbox.
  */
 const ProjectManifestV2 = z.object({
   schemaVersion: z.literal(2),
@@ -177,13 +217,17 @@ const ProjectManifestV2 = z.object({
   tags: z.array(z.string()).default([]),
   thumbnail: z.string().optional(),
   completionLevel: z.enum(['wip', 'works', 'ships']),
-  /** v2's defining field: at least one renderable artifact. */
-  assets: z.array(Asset).min(1, 'v2 manifest must declare at least one asset'),
+  /** Optional. When omitted, the project page renders overview-only. */
+  assets: z.array(Asset).optional(),
   /** Which asset is shown when the visitor lands on /projects/<slug>
-   *  with no `?asset` query param. Defaults to the first asset's id. */
+   *  with no `?asset` query param. Defaults to the first asset's id.
+   *  Ignored when assets is empty. */
   defaultAssetId: z.string().optional(),
-  delivery: Delivery,
-  build: Build,
+  /** Optional unless `assets` is non-empty (where do the assets live?). */
+  delivery: Delivery.optional(),
+  build: Build.optional(),
+  /** Where the long-form project narrative lives (defaults to README.md). */
+  overview: OverviewSource.optional(),
 })
 type ProjectManifestV2 = z.infer<typeof ProjectManifestV2>
 
@@ -203,9 +247,22 @@ export type ProjectManifest = z.infer<typeof ProjectManifest>
 /**
  * The shape consumers (UI, content collection) actually work with.
  *
- * Always v2-shaped: `assets[]` is non-empty, `defaultAssetId` is
- * resolved. v1 manifests are upgraded by `normalizeManifest`.
+ * Always v2-shaped. v1 manifests are upgraded by `normalizeManifest`.
+ *
+ * `assets` may be empty — those are overview-only projects (a portfolio
+ * page for a project with no playable demo). `delivery` and `build` are
+ * present iff `assets` is non-empty.
+ *
+ * `overview` is always present as a NormalizedOverview — falls back to
+ * `{ path: 'README.md', skipFirstHeading: true }` when the manifest
+ * doesn't declare one.
  */
+const NormalizedOverview = z.object({
+  path: z.string(),
+  skipFirstHeading: z.boolean(),
+})
+export type NormalizedOverview = z.infer<typeof NormalizedOverview>
+
 export const NormalizedManifest = z.object({
   slug: z.string(),
   category: Category,
@@ -214,12 +271,24 @@ export const NormalizedManifest = z.object({
   tags: z.array(z.string()),
   thumbnail: z.string().optional(),
   completionLevel: z.enum(['wip', 'works', 'ships']),
-  assets: z.array(Asset).min(1),
+  /** May be empty for overview-only projects. */
+  assets: z.array(Asset),
+  /** Empty string when assets is empty. */
   defaultAssetId: z.string(),
-  delivery: Delivery,
-  build: Build,
+  /** Undefined when assets is empty. */
+  delivery: Delivery.optional(),
+  /** Undefined when assets is empty. */
+  build: Build.optional(),
+  /** Always set; defaults to README.md / skipFirstHeading=true. */
+  overview: NormalizedOverview,
 })
 export type NormalizedManifest = z.infer<typeof NormalizedManifest>
+
+/** Default overview source when manifest doesn't specify one. */
+export const DEFAULT_OVERVIEW: NormalizedOverview = {
+  path: 'README.md',
+  skipFirstHeading: true,
+}
 
 /**
  * Discovery metadata that the personal site adds to a manifest *after*
@@ -250,12 +319,16 @@ export type ProjectEntry = z.infer<typeof ProjectEntry>
 
 /**
  * Upgrade a v1 manifest to the v2-shaped `NormalizedManifest`. v2
- * manifests pass through with `defaultAssetId` resolved.
+ * manifests pass through with `defaultAssetId` resolved and `overview`
+ * defaulted.
  *
  * v1 → v2 strategy: synthesize a single asset with id `'main'` from
  * the top-level `embed`. The asset takes its `title` from a heuristic:
  * for `static-html`/`tex-pdf`/etc., we use the project's title; the
  * embed kind is preserved verbatim.
+ *
+ * For overview-only v2 manifests (no `assets`), the result has empty
+ * `assets`, empty `defaultAssetId`, and undefined `delivery` / `build`.
  *
  * This is a pure function; safe to call from the discovery script and
  * from any astro/vite consumer.
@@ -280,13 +353,25 @@ export function normalizeManifest(m: ProjectManifest): NormalizedManifest {
       defaultAssetId: 'main',
       delivery: m.delivery,
       build: m.build,
+      overview: DEFAULT_OVERVIEW,
     }
   }
-  // v2: validate that defaultAssetId (if set) matches a real asset.
-  // Fall back to assets[0].id otherwise.
-  const ids = new Set(m.assets.map(a => a.id))
-  const fallback = m.assets[0]!.id
-  const defaultAssetId = m.defaultAssetId && ids.has(m.defaultAssetId) ? m.defaultAssetId : fallback
+  // v2: normalize.
+  const assets = m.assets ?? []
+  const defaultAssetId =
+    assets.length === 0
+      ? ''
+      : (() => {
+          const ids = new Set(assets.map((a) => a.id))
+          const fallback = assets[0]!.id
+          return m.defaultAssetId && ids.has(m.defaultAssetId) ? m.defaultAssetId : fallback
+        })()
+  const overview: NormalizedOverview = m.overview
+    ? {
+        path: m.overview.path,
+        skipFirstHeading: m.overview.skipFirstHeading,
+      }
+    : DEFAULT_OVERVIEW
   return {
     slug: m.slug,
     category: m.category,
@@ -295,9 +380,10 @@ export function normalizeManifest(m: ProjectManifest): NormalizedManifest {
     tags: m.tags,
     thumbnail: m.thumbnail,
     completionLevel: m.completionLevel,
-    assets: m.assets,
+    assets,
     defaultAssetId,
     delivery: m.delivery,
     build: m.build,
+    overview,
   }
 }

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -342,28 +342,46 @@ const isStaleVersion = hasDemo && activeVersion !== entry.delivery!.version
 <style is:global>
   /* Style the rendered markdown overview */
   .prose pre {
-    @apply overflow-x-auto rounded-lg border bg-background/40 p-3 text-xs;
+    overflow-x: auto;
+    border-radius: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    background-color: hsl(var(--background) / 0.4);
+    padding: 0.75rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
   }
   .prose code {
-    @apply rounded bg-muted px-1 py-0.5 text-[0.85em];
+    border-radius: 0.25rem;
+    background-color: hsl(var(--muted));
+    padding: 0.125rem 0.25rem;
+    font-size: 0.85em;
   }
   .prose pre code {
-    @apply bg-transparent p-0;
+    background-color: transparent;
+    padding: 0;
   }
   .prose a {
-    @apply text-primary underline-offset-2 hover:underline;
+    color: hsl(var(--primary));
+    text-underline-offset: 2px;
+  }
+  .prose a:hover {
+    text-decoration: underline;
   }
   .prose img {
-    @apply rounded-lg border;
+    border-radius: 0.5rem;
+    border: 1px solid hsl(var(--border));
   }
   .prose blockquote {
-    @apply border-l-2 border-primary/40 pl-4 italic;
+    border-left: 2px solid hsl(var(--primary) / 0.4);
+    padding-left: 1rem;
+    font-style: italic;
   }
   .prose table {
-    @apply text-sm;
+    font-size: 0.875rem;
   }
   .prose th,
   .prose td {
-    @apply border-border px-3 py-1.5;
+    border-color: hsl(var(--border));
+    padding: 0.375rem 0.75rem;
   }
 </style>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -2,18 +2,23 @@
 /**
  * /projects/[slug] — individual project page.
  *
- * Renders the active asset's embed (selected via `?asset=<id>`, defaults
- * to `manifest.defaultAssetId`) in the page's centerpiece, with a
- * sidebar showing project metadata, a tab strip for switching assets,
- * and a version picker for switching to historical builds.
+ * Renders three things in priority order:
+ * 1. **Header** with title, category, completion-status pill, "View on
+ *    GitHub" button (always visible).
+ * 2. **Live demo** (if `entry.assets[]` is non-empty): asset tabs + iframe
+ *    sandbox + version picker. Selected via `?asset=<id>` and `?v=<sha>`.
+ * 3. **Overview**: rendered Markdown narrative pulled from the source
+ *    repo's README (or the path declared in `manifest.overview`). Always
+ *    rendered. For projects without a live demo, the overview IS the
+ *    centerpiece.
  *
- * Why request-time SSR (not prerender): the page accepts two query
- * params that affect what it renders:
- * - `?asset=<id>` — handled client-side by ProjectViewer
- * - `?v=<sha>` — affects the deliveryUrl that the embed loads from.
- *   We resolve this server-side so deep-links to old versions render
- *   the right artifact even if the URL is shared as a static link
- *   (no JS execution required to see the right thing).
+ * Why request-time SSR (not prerender):
+ * - `?v=<sha>` affects the deliveryUrl that the embed loads from. We
+ *   resolve this server-side so deep-links to old versions render the
+ *   right artifact even from a static link.
+ * - The README is fetched from GitHub at request time and cached at the
+ *   CDN edge. (Build-time fetch is also fine, but request-time keeps
+ *   the README fresh without a deploy on every README change.)
  *
  * The Worker is already running for /api/embed-upload and the
  * /api/projects/[slug]/versions route; one more SSR route is cheap.
@@ -24,6 +29,7 @@ import ProjectViewer from '@/components/embeds/ProjectViewer'
 import VersionPicker from '@/components/embeds/VersionPicker'
 import { getCollection } from 'astro:content'
 import { PROJECT_SLUG_REDIRECTS } from '@/lib/project-redirects'
+import { fetchRenderedOverview } from '@/lib/project-overview'
 
 const { slug } = Astro.params
 if (typeof slug !== 'string' || !slug) {
@@ -45,19 +51,21 @@ if (!matched) {
 }
 
 const entry = matched.data
+const hasDemo = entry.assets.length > 0
 
-// ── version override ─────────────────────────────────────────────
-// `?v=<sha>` swaps the delivery prefix to a historical build. We don't
-// validate against R2 here — if the version doesn't exist, the iframe
-// will 404 and the user can pick another. (We could pre-check by
-// HEAD'ing the bucket, but that's a Worker round-trip per request and
-// not worth it for a portfolio site.)
+// ── version override (only applies when there's a demo) ──────────────
 const requestedVersion = Astro.url.searchParams.get('v')
 const VERSION_RE = /^[a-z0-9._-]{1,64}$/i
 
-let activeVersion = entry.delivery.version
-let activeDeliveryUrl = entry.delivery.url
-if (requestedVersion && VERSION_RE.test(requestedVersion) && requestedVersion !== entry.delivery.version) {
+let activeVersion: string | undefined = entry.delivery?.version
+let activeDeliveryUrl: string | undefined = entry.delivery?.url
+if (
+  hasDemo &&
+  entry.delivery &&
+  requestedVersion &&
+  VERSION_RE.test(requestedVersion) &&
+  requestedVersion !== entry.delivery.version
+) {
   // Replace the version segment in the delivery URL. The convention is
   // `https://assets-r2.codeseys.io/<slug>/<version>/`; we splice the new
   // version in. If the URL doesn't match the convention, fall back to
@@ -71,6 +79,14 @@ if (requestedVersion && VERSION_RE.test(requestedVersion) && requestedVersion !=
     activeVersion = requestedVersion
   }
 }
+
+// ── overview fetch (always attempted, fail-soft) ──────────────────────
+const overviewResult = await fetchRenderedOverview({
+  source: entry.discovery.source,
+  ref: entry.discovery.ref,
+  path: entry.overview.path,
+  skipFirstHeading: entry.overview.skipFirstHeading,
+})
 
 // ── helpers ──────────────────────────────────────────────────────
 
@@ -112,7 +128,7 @@ const sourceUrl = `https://github.com/${entry.discovery.source}`
 const ogDescription =
   entry.description.length > 160 ? entry.description.slice(0, 157).trimEnd() + '…' : entry.description
 
-const isStaleVersion = activeVersion !== entry.delivery.version
+const isStaleVersion = hasDemo && activeVersion !== entry.delivery!.version
 ---
 
 <BaseLayout
@@ -138,14 +154,32 @@ const isStaleVersion = activeVersion !== entry.delivery.version
           {entry.description}
         </p>
       </div>
-      <div class="inline-flex shrink-0 items-center gap-2 rounded-md border bg-card px-2.5 py-1.5 text-xs">
-        <span class={`size-1.5 rounded-full ${dot.class}`} />
-        <span class="font-medium text-foreground">{dot.label}</span>
+      <div class="flex shrink-0 flex-col items-end gap-2">
+        <a
+          href={sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 rounded-md border bg-background/60 px-3 py-1.5 text-sm font-medium text-foreground shadow-sm transition hover:border-primary hover:bg-primary/10 hover:text-primary"
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor" class="size-4" aria-hidden="true">
+            <path d="M12 .5a11.5 11.5 0 0 0-3.6 22.4c.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.6-1.3-1.6-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.2 1.2.9-.3 1.9-.4 2.9-.4s2 .1 2.9.4c2.2-1.5 3.2-1.2 3.2-1.2.6 1.7.2 2.9.1 3.2.7.8 1.2 1.9 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A11.5 11.5 0 0 0 12 .5z" />
+          </svg>
+          View on GitHub
+        </a>
+        <div class="inline-flex items-center gap-2 rounded-md border bg-card px-2.5 py-1.5 text-xs">
+          <span class={`size-1.5 rounded-full ${dot.class}`} />
+          <span class="font-medium text-foreground">{dot.label}</span>
+          {!hasDemo && (
+            <span class="ml-1 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+              Overview only
+            </span>
+          )}
+        </div>
       </div>
     </header>
 
     {
-      isStaleVersion && (
+      isStaleVersion && entry.delivery && (
         <div class="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs">
           <span class="text-amber-200">
             Viewing historical version <code class="font-mono font-semibold">{activeVersion}</code> — current is <code class="font-mono font-semibold">{entry.delivery.version}</code>.
@@ -157,18 +191,20 @@ const isStaleVersion = activeVersion !== entry.delivery.version
       )
     }
 
-    <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
-      {/* Embed centerpiece — asset tab strip + active embed */}
-      <div class="min-w-0">
-        <ProjectViewer
-          assets={entry.assets}
-          defaultAssetId={entry.defaultAssetId}
-          deliveryUrl={activeDeliveryUrl}
-          client:load
-        />
+    <div class={hasDemo ? "grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]" : "grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]"}>
+      {/* Main column — embed (if any) + overview */}
+      <div class="min-w-0 space-y-8">
+        {hasDemo && entry.delivery && (
+          <ProjectViewer
+            assets={entry.assets}
+            defaultAssetId={entry.defaultAssetId}
+            deliveryUrl={activeDeliveryUrl!}
+            client:load
+          />
+        )}
 
         {entry.tags.length > 0 && (
-          <div class="mt-4 flex flex-wrap gap-1.5">
+          <div class="flex flex-wrap gap-1.5">
             {entry.tags.map((tag) => (
               <span class="inline-flex items-center rounded-md border bg-background/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
                 {tag}
@@ -176,6 +212,39 @@ const isStaleVersion = activeVersion !== entry.delivery.version
             ))}
           </div>
         )}
+
+        {/* Overview / README centerpiece */}
+        <section class="prose prose-invert max-w-none">
+          <header class="not-prose mb-4 flex items-baseline justify-between gap-3 border-b pb-2">
+            <h2 class="text-base font-semibold uppercase tracking-wide text-muted-foreground">
+              Overview
+            </h2>
+            <a
+              href={`${sourceUrl}/blob/${entry.discovery.ref}/${entry.overview.path}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="font-mono text-[11px] text-muted-foreground hover:text-primary"
+            >
+              {entry.overview.path} ↗
+            </a>
+          </header>
+          {overviewResult.ok ? (
+            <Fragment set:html={overviewResult.html} />
+          ) : (
+            <div class="rounded-md border border-amber-400/30 bg-amber-400/5 p-3 text-xs text-muted-foreground">
+              <p class="font-medium text-amber-200">
+                Couldn't fetch overview from <code class="font-mono">{entry.overview.path}</code>.
+              </p>
+              <p class="mt-1">
+                {overviewResult.error}.{' '}
+                <a class="text-amber-200 underline-offset-2 hover:underline" href={sourceUrl} target="_blank" rel="noopener noreferrer">
+                  View the repo on GitHub instead
+                </a>
+                .
+              </p>
+            </div>
+          )}
+        </section>
       </div>
 
       <aside class="space-y-4 text-sm">
@@ -187,12 +256,12 @@ const isStaleVersion = activeVersion !== entry.delivery.version
             href={sourceUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="font-mono text-xs text-foreground hover:text-primary"
+            class="block break-all font-mono text-xs text-foreground hover:text-primary"
           >
             {entry.discovery.source}
           </a>
           {
-            entry.build.workflow && (
+            entry.build?.workflow && (
               <p class="mt-2 text-xs text-muted-foreground">
                 Built by{' '}
                 <a
@@ -208,45 +277,49 @@ const isStaleVersion = activeVersion !== entry.delivery.version
           }
         </div>
 
-        <div class="rounded-xl border bg-card p-4">
-          <h2 class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Artifact
-          </h2>
-          <dl class="space-y-2 text-xs">
-            <div class="flex items-baseline justify-between gap-2">
-              <dt class="text-muted-foreground">Assets</dt>
-              <dd class="font-mono text-foreground">{entry.assets.length}</dd>
+        {hasDemo && entry.delivery && (
+          <>
+            <div class="rounded-xl border bg-card p-4">
+              <h2 class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Artifact
+              </h2>
+              <dl class="space-y-2 text-xs">
+                <div class="flex items-baseline justify-between gap-2">
+                  <dt class="text-muted-foreground">Assets</dt>
+                  <dd class="font-mono text-foreground">{entry.assets.length}</dd>
+                </div>
+                <div class="flex items-baseline justify-between gap-2">
+                  <dt class="text-muted-foreground">Delivery</dt>
+                  <dd class="font-mono text-foreground">{entry.delivery.mode}</dd>
+                </div>
+                <div class="flex items-baseline justify-between gap-2">
+                  <dt class="text-muted-foreground">Pinned</dt>
+                  <dd class="font-mono text-foreground">{entry.delivery.version}</dd>
+                </div>
+                <div class="flex items-baseline justify-between gap-2">
+                  <dt class="text-muted-foreground">Total size</dt>
+                  <dd class="font-mono text-foreground">{formatBytes(entry.delivery.sizeBytes)}</dd>
+                </div>
+              </dl>
             </div>
-            <div class="flex items-baseline justify-between gap-2">
-              <dt class="text-muted-foreground">Delivery</dt>
-              <dd class="font-mono text-foreground">{entry.delivery.mode}</dd>
+
+            <div class="rounded-xl border bg-card p-4">
+              <h2 class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Versions
+              </h2>
+              <VersionPicker
+                slug={entry.slug}
+                currentVersion={entry.delivery.version}
+                activeVersion={activeVersion!}
+                client:load
+              />
             </div>
-            <div class="flex items-baseline justify-between gap-2">
-              <dt class="text-muted-foreground">Pinned</dt>
-              <dd class="font-mono text-foreground">{entry.delivery.version}</dd>
-            </div>
-            <div class="flex items-baseline justify-between gap-2">
-              <dt class="text-muted-foreground">Total size</dt>
-              <dd class="font-mono text-foreground">{formatBytes(entry.delivery.sizeBytes)}</dd>
-            </div>
-          </dl>
-        </div>
+          </>
+        )}
 
         <div class="rounded-xl border bg-card p-4">
           <h2 class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Versions
-          </h2>
-          <VersionPicker
-            slug={entry.slug}
-            currentVersion={entry.delivery.version}
-            activeVersion={activeVersion}
-            client:load
-          />
-        </div>
-
-        <div class="rounded-xl border bg-card p-4">
-          <h2 class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            About this embed
+            About this {hasDemo ? 'embed' : 'page'}
           </h2>
           <p class="text-xs leading-relaxed text-muted-foreground">
             Discovered automatically by topic <code class="rounded bg-muted px-1">codeseys-embed</code>.
@@ -261,3 +334,36 @@ const isStaleVersion = activeVersion !== entry.delivery.version
     </div>
   </main>
 </BaseLayout>
+
+<script>
+  // Add any client-side enhancements here
+</script>
+
+<style is:global>
+  /* Style the rendered markdown overview */
+  .prose pre {
+    @apply overflow-x-auto rounded-lg border bg-background/40 p-3 text-xs;
+  }
+  .prose code {
+    @apply rounded bg-muted px-1 py-0.5 text-[0.85em];
+  }
+  .prose pre code {
+    @apply bg-transparent p-0;
+  }
+  .prose a {
+    @apply text-primary underline-offset-2 hover:underline;
+  }
+  .prose img {
+    @apply rounded-lg border;
+  }
+  .prose blockquote {
+    @apply border-l-2 border-primary/40 pl-4 italic;
+  }
+  .prose table {
+    @apply text-sm;
+  }
+  .prose th,
+  .prose td {
+    @apply border-border px-3 py-1.5;
+  }
+</style>


### PR DESCRIPTION
## Summary

Three changes to /projects/[slug]:

1. **'View on GitHub' button** prominently in the header (was a small sidebar link)
2. **README rendering** as an Overview section (request-time fetch from raw.githubusercontent.com, edge-cached, marked-rendered)
3. **Build-step support** in the reusable workflow — manifests can declare `build.script` + `build.aptPackages`

Plus schema relaxation to support overview-only projects (no live demo, just a portfolio page).

## Companion change

[web-embed-workflows#3](https://github.com/baladithyab/web-embed-workflows/pulls) (next PR) extends the reusable workflow with apt-install + build-script steps.

## Tests

178 / 178 (was 163). +12 overview-lib tests, +3 schema-update tests.
🤖 Generated with the help of Claude